### PR TITLE
Switch to user ID for submissions

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/UserService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/UserService.java
@@ -3,7 +3,9 @@ package io.github.sanyavertolet.edukate.backend.services;
 import io.github.sanyavertolet.edukate.backend.repositories.UserRepository;
 import io.github.sanyavertolet.edukate.common.UserStatus;
 import io.github.sanyavertolet.edukate.common.entities.User;
+import io.github.sanyavertolet.edukate.common.utils.AuthUtils;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Mono;
 
@@ -11,6 +13,10 @@ import reactor.core.publisher.Mono;
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+
+    public Mono<User> findUserByAuthentication(Authentication authentication) {
+        return AuthUtils.monoId(authentication).flatMap(this::findUserById);
+    }
 
     public Mono<User> saveUser(User user) {
         return userRepository.save(user);


### PR DESCRIPTION
This PR closes #7 

### What's done:
 * Replaced usage of `authentication.getName()` with `AuthUtils.monoId` for user ID extraction in controllers and services.
 * Updated `SubmissionController`, `FileController`, and `SubmissionService` to use user ID instead of username.
 * Adjusted `UserService` to include `findUserByAuthentication` for fetching user by authentication.
 * Enhanced role handling in `SubmissionController` to allow `ADMIN` in addition to `MODERATOR`.