### PR TITLE
Handle null authentication in `AuthUtils`

### DIFF
--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/utils/AuthUtils.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/utils/AuthUtils.java
@@ -10,11 +10,14 @@ public class AuthUtils {
     }
 
     public static String id(Authentication authentication) {
+        if (authentication == null) {
+            return null;
+        }
         EdukateUserDetails userDetails = (EdukateUserDetails) authentication.getPrincipal();
         return userDetails.getId();
     }
 
     public static Mono<String> monoId(Authentication authentication) {
-        return Mono.fromCallable(() -> id(authentication));
+        return Mono.justOrEmpty(id(authentication));
     }
 }


### PR DESCRIPTION
### What's done:
 * Added null check for `authentication` in `id` method of `AuthUtils` to prevent `NullPointerException`.
 * Updated `monoId` method to use `Mono.justOrEmpty` for handling null values gracefully.