### PR TITLE
Implement MongoDB integration for file metadata management

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/configs/MongoConfig.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/configs/MongoConfig.java
@@ -1,0 +1,8 @@
+package io.github.sanyavertolet.edukate.backend.configs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableReactiveMongoAuditing;
+
+@Configuration
+@EnableReactiveMongoAuditing
+public class MongoConfig { }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObject.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObject.java
@@ -1,0 +1,43 @@
+package io.github.sanyavertolet.edukate.backend.entities.files;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Document(collection = "file_objects")
+public class FileObject {
+    @Id
+    private String id;
+
+    @Indexed(unique = true)
+    private String keyPath;
+
+    private FileKey key;
+
+    private String type;
+
+    private String ownerUserId;
+
+    private FileObjectMetadata metadata;
+
+    @CreatedDate
+    private Instant createdAt;
+
+    @LastModifiedDate
+    private Instant updatedAt;
+
+    @Builder.Default
+    private Integer metaVersion = 1;
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObjectMetadata.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObjectMetadata.java
@@ -1,0 +1,17 @@
+package io.github.sanyavertolet.edukate.backend.entities.files;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FileObjectMetadata {
+    private Instant lastModified;
+    private Long contentLength;
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ProblemFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ProblemFileKey.java
@@ -1,14 +1,20 @@
 package io.github.sanyavertolet.edukate.backend.entities.files;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.TypeAlias;
 
 @TypeAlias("problem")
 @JsonTypeName("problem")
+@EqualsAndHashCode(callSuper = true, of = {"problemId"})
 public class ProblemFileKey extends FileKey {
+    @Getter
     private final String problemId;
 
-    private ProblemFileKey(String problemId, String fileName) {
+    @PersistenceCreator
+    public ProblemFileKey(String problemId, String fileName) {
         super(fileName);
         this.problemId = problemId;
     }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ResultFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ResultFileKey.java
@@ -1,14 +1,20 @@
 package io.github.sanyavertolet.edukate.backend.entities.files;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.TypeAlias;
 
 @TypeAlias("result")
 @JsonTypeName("result")
+@EqualsAndHashCode(callSuper = true, of = {"problemId"})
 public class ResultFileKey extends FileKey {
+    @Getter
     private final String problemId;
 
-    private ResultFileKey(String problemId, String fileName) {
+    @PersistenceCreator
+    public ResultFileKey(String problemId, String fileName) {
         super(fileName);
         this.problemId = problemId;
     }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/SubmissionFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/SubmissionFileKey.java
@@ -1,11 +1,14 @@
 package io.github.sanyavertolet.edukate.backend.entities.files;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.TypeAlias;
 
 @TypeAlias("submission")
 @JsonTypeName("submission")
+@EqualsAndHashCode(callSuper = true, of = {"userId", "problemId", "submissionId"})
 public class SubmissionFileKey extends FileKey {
     @Getter
     private final String userId;
@@ -14,7 +17,8 @@ public class SubmissionFileKey extends FileKey {
     @Getter
     private final String submissionId;
 
-    private SubmissionFileKey(String userId, String problemId, String submissionId, String fileName) {
+    @PersistenceCreator
+    public SubmissionFileKey(String userId, String problemId, String submissionId, String fileName) {
         super(fileName);
         this.userId = userId;
         this.problemId = problemId;

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/TempFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/TempFileKey.java
@@ -1,15 +1,21 @@
 package io.github.sanyavertolet.edukate.backend.entities.files;
 
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.TypeAlias;
 
 @TypeAlias("tmp")
 @JsonTypeName("tmp")
+@EqualsAndHashCode(callSuper = true, of = {"userId"})
 public class TempFileKey extends FileKey {
+    @Getter
     private final String userId;
 
-    private TempFileKey(String userId, String key) {
-        super(key);
+    @PersistenceCreator
+    public TempFileKey(String userId, String fileName) {
+        super(fileName);
         this.userId = userId;
     }
 

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/FileObjectRepository.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/FileObjectRepository.java
@@ -1,0 +1,17 @@
+package io.github.sanyavertolet.edukate.backend.repositories;
+
+import io.github.sanyavertolet.edukate.backend.entities.files.FileObject;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Repository
+public interface FileObjectRepository extends ReactiveMongoRepository<FileObject, String> {
+
+    Mono<FileObject> findByKeyPath(String keyPath);
+
+    Flux<FileObject> findAllByKeyPathStartingWith(String prefix);
+
+    Mono<Long> deleteByKeyPath(String keyPath);
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/BaseFileService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/BaseFileService.java
@@ -1,21 +1,27 @@
 package io.github.sanyavertolet.edukate.backend.services.files;
 
 import io.github.sanyavertolet.edukate.backend.dtos.FileMetadata;
-import io.github.sanyavertolet.edukate.backend.entities.files.FileKey;
+import io.github.sanyavertolet.edukate.backend.entities.files.*;
+import io.github.sanyavertolet.edukate.backend.repositories.FileObjectRepository;
 import io.github.sanyavertolet.edukate.backend.storage.Storage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.util.function.Tuples;
 
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class BaseFileService {
+    private final FileObjectRepository fileObjectRepository;
     private final Storage<FileKey> storage;
 
     public Flux<ByteBuffer> getFile(FileKey key) {
@@ -27,11 +33,26 @@ public class BaseFileService {
     }
 
     public Mono<FileKey> uploadFile(FileKey key, Flux<ByteBuffer> content) {
-        return storage.upload(key, content);
+        return storage.upload(key, content)
+                .flatMap(k -> fetchBasicMetadata(k)
+                        .flatMap(meta -> saveOrUpdateByKeyPath(k.toString(), k, meta))
+                        .thenReturn(k)
+                );
     }
 
     public Mono<Boolean> deleteFile(FileKey key) {
-        return storage.delete(key);
+        return storage.delete(key).flatMap(success -> success
+                ? fileObjectRepository.deleteByKeyPath(key.toString())
+                .doOnSuccess(cnt -> {
+                    if (cnt != null && cnt > 0) {
+                        log.info("Deleted file object with key path {}", key);
+                    } else {
+                        log.warn("Storage deleted but no DB record found for key path {}", key);
+                    }
+                })
+                .thenReturn(true)
+                : Mono.just(false)
+        );
     }
 
     public Mono<Boolean> doesFileExist(FileKey key) {
@@ -46,27 +67,73 @@ public class BaseFileService {
         return Mono.justOrEmpty(oldKey)
                 .flatMap(key -> storage.move(key, newKey))
                 .flatMap(success -> success
-                        ? Mono.just(newKey)
+                        ? fetchBasicMetadata(newKey)
+                            .flatMap(meta -> saveOrUpdateByKeyPath(oldKey.toString(), newKey, meta))
+                            .thenReturn(newKey)
                         : Mono.error(new IllegalStateException("Move failed: " + oldKey + " -> " + newKey))
                 );
     }
 
-    public Flux<FileKey> listFilesWithPrefix(String prefix) {
-        return Mono.justOrEmpty(prefix).flatMapMany(storage::prefixedList);
+    public Flux<FileMetadata> listFileMetadataWithPrefix(String prefix, String authorName) {
+        return fileObjectRepository.findAllByKeyPathStartingWith(prefix)
+                .map(fo -> FileMetadata.of(
+                        fo.getKey() != null ? fo.getKey().getFileName() : fo.getKeyPath(),
+                        authorName,
+                        fo.getMetadata() != null && fo.getMetadata().getLastModified() != null
+                                ? LocalDateTime.ofInstant(fo.getMetadata().getLastModified(), ZoneId.systemDefault())
+                                : null,
+                        fo.getMetadata() != null ? fo.getMetadata().getContentLength() : null
+                ));
     }
 
-    public Flux<FileMetadata> listFileMetadataWithPrefix(String prefix, String authorName) {
-        return listFilesWithPrefix(prefix)
-                .flatMap(key -> Mono.zip(
-                        Mono.just(key),
-                        storage.lastModified(key),
-                        storage.contentLength(key)
-                ))
-                .map(tuple -> FileMetadata.of(
-                        tuple.getT1().getFileName(),
-                        authorName,
-                        LocalDateTime.ofInstant(tuple.getT2(), ZoneId.systemDefault()),
-                        tuple.getT3()
-                ));
+    private static String typeOf(FileKey key) {
+        if (key instanceof TempFileKey) return "tmp";
+        if (key instanceof SubmissionFileKey) return "submission";
+        if (key instanceof ProblemFileKey) return "problem";
+        if (key instanceof ResultFileKey) return "result";
+        return "base";
+    }
+
+    private static String ownerOf(FileKey key) {
+        if (key instanceof TempFileKey tmp) return tmp.getUserId();
+        if (key instanceof SubmissionFileKey sub) return sub.getUserId();
+        return null;
+    }
+
+    private Mono<FileObjectMetadata> fetchBasicMetadata(FileKey key) {
+        return Mono.zip(storage.lastModified(key), storage.contentLength(key))
+                .defaultIfEmpty(Tuples.of(Instant.now(), 0L))
+                .map(t -> FileObjectMetadata.builder()
+                        .lastModified(t.getT1())
+                        .contentLength(t.getT2())
+                        .build()
+                );
+    }
+
+    private Mono<FileObject> saveOrUpdateByKeyPath(String lookupKeyPath, FileKey newKey, FileObjectMetadata metadata) {
+        String newPath = newKey.toString();
+        String type = typeOf(newKey);
+        String owner = ownerOf(newKey);
+        return fileObjectRepository.findByKeyPath(lookupKeyPath)
+                .flatMap(existing -> {
+                    existing.setKey(newKey);
+                    existing.setKeyPath(newPath);
+                    existing.setType(type);
+                    existing.setOwnerUserId(owner);
+                    existing.setMetadata(metadata);
+                    return fileObjectRepository.save(existing).doOnSuccess(updated ->
+                            log.info("Updated file object with key path {}: {}", lookupKeyPath, updated.getKey()));
+                })
+                .switchIfEmpty(fileObjectRepository.save(
+                        FileObject.builder()
+                                .keyPath(newPath)
+                                .key(newKey)
+                                .type(type)
+                                .ownerUserId(owner)
+                                .metadata(metadata)
+                                .metaVersion(1)
+                                .build())
+                        .doOnSuccess(created -> log.info("Created file object with key path {}", created.getKey()))
+                );
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/TempFileService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/TempFileService.java
@@ -19,10 +19,6 @@ public class TempFileService {
         return baseFileService.doesFileExist(TempFileKey.of(userId, fileName));
     }
 
-    public Flux<FileKey> listFiles(String userId) {
-        return baseFileService.listFilesWithPrefix(TempFileKey.prefix(userId));
-    }
-
     public Flux<FileMetadata> listFileMetadata(String userId) {
         return baseFileService.listFileMetadataWithPrefix(TempFileKey.prefix(userId), userId);
     }


### PR DESCRIPTION
This PR closes #15 

### What's done:
 * Added `FileObject` and `FileObjectMetadata` entities for storing metadata in MongoDB.
 * Created `FileObjectRepository` interface with reactive methods for database operations.
 * Updated `BaseFileService` to handle file metadata, including saving, updating, and deleting records.
 * Enabled reactive MongoDB auditing via `MongoConfig`.
 * Enhanced `FileKey` classes with constructors and `EqualsAndHashCode` annotations.
 * Refactored logic for managing key-based file metadata across services.