### PR TITLE
Refactor `submissions` collection to store `FileObject` references

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
@@ -106,7 +106,7 @@ public class SubmissionController {
                 .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.FORBIDDEN, "Not enough permission")))
                 .filterWhen(_ -> problemService.findProblemById(submissionRequest.getProblemId()).hasElement())
                 .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Problem not found.")))
-                .flatMap(user -> Flux.fromIterable(submissionRequest.getFileKeys())
+                .flatMap(user -> Flux.fromIterable(submissionRequest.getFileNames())
                         .map(fileName -> TempFileKey.of(user.getId(), fileName))
                         .cast(FileKey.class)
                         .collectList()

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/CreateSubmissionRequest.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/CreateSubmissionRequest.java
@@ -11,5 +11,5 @@ import java.util.List;
 @NoArgsConstructor
 public class CreateSubmissionRequest {
     private String problemId;
-    private List<String> fileKeys;
+    private List<String> fileNames;
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Submission.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Submission.java
@@ -19,7 +19,7 @@ public class Submission {
     private String problemId;
     private String userId;
     private Status status;
-    private List<String> fileKeys;
+    private List<String> fileObjectIds;
     private Instant createdAt;
 
     public enum Status {
@@ -28,8 +28,8 @@ public class Submission {
         FAILED
     }
 
-    public static Submission of(String problemId, String userId, List<String> fileKeys) {
-        return new Submission(null, problemId, userId, Status.PENDING, fileKeys, Instant.now(Clock.systemUTC()));
+    public static Submission of(String problemId, String userId) {
+        return new Submission(null, problemId, userId, Status.PENDING, List.of(), Instant.now(Clock.systemUTC()));
     }
 
     public Submission markAs(Status status) {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/SubmissionFileService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/SubmissionFileService.java
@@ -17,7 +17,7 @@ public class SubmissionFileService {
     private final BaseFileService baseFileService;
 
     public Mono<List<FileKey>> moveSubmissionFiles(String userId, String submissionId, CreateSubmissionRequest request) {
-        return Flux.fromIterable(request.getFileKeys())
+        return Flux.fromIterable(request.getFileNames())
                 .flatMap(file -> baseFileService.moveFile(
                         TempFileKey.of(userId, file),
                         SubmissionFileKey.of(userId, request.getProblemId(), submissionId, file)))

--- a/edukate-frontend/src/components/files/FileUploadComponent.tsx
+++ b/edukate-frontend/src/components/files/FileUploadComponent.tsx
@@ -6,27 +6,27 @@ interface FileUploadComponentProps {
     accept?: string;
     maxSize?: number;
     maxFiles?: number;
-    onSubmit?: (fileKeys: string[]) => void;
+    onSubmit?: (fileNames: string[]) => void;
 }
 
 export function FileUploadComponent(
     { accept = "*", maxSize = 50 * 1024 * 1024, maxFiles = 5, onSubmit }: FileUploadComponentProps
 ) {
-    const [uploadedFileKeys, setUploadedFileKeys] = useState<string[]>([]);
+    const [uploadedFileNames, setUploadedFileNames] = useState<string[]>([]);
     const addFileKey = (fileKey: string) => {
-        setUploadedFileKeys(prevState => [...prevState, fileKey]);
+        setUploadedFileNames(prevState => [...prevState, fileKey]);
     };
     const deleteFileKey = (fileKey: string) => {
-        setUploadedFileKeys(prevState => prevState.filter(key => key !== fileKey));
+        setUploadedFileNames(prevState => prevState.filter(key => key !== fileKey));
     };
     return (
         <Paper elevation={2} sx={{p: 1, borderRadius: 2, width: "60%"}}>
             <Box gap={2}>
                 <FileInputComponent onTempFileUploaded={addFileKey} onTempFileDeleted={deleteFileKey} accept={accept}
                                     maxFiles={maxFiles} maxSize={maxSize}/>
-                { onSubmit && uploadedFileKeys.length > 0 && (
+                { onSubmit && uploadedFileNames.length > 0 && (
                     <Button variant={"text"} color={"secondary"} sx={{ mb: 1 }}
-                        onClick={() => onSubmit(uploadedFileKeys)}>Submit</Button>
+                        onClick={() => onSubmit(uploadedFileNames)}>Submit</Button>
                 )}
             </Box>
         </Paper>

--- a/edukate-frontend/src/components/files/MobileFileUploadComponent.tsx
+++ b/edukate-frontend/src/components/files/MobileFileUploadComponent.tsx
@@ -7,28 +7,28 @@ interface MobileFileUploadComponentProps {
     accept?: string;
     maxSize?: number;
     maxFiles?: number;
-    onSubmit?: (fileKeys: string[]) => void;
+    onSubmit?: (fileNames: string[]) => void;
 }
 
 export function MobileFileUploadComponent(
     { accept = "*", maxSize = 50 * 1024 * 1024, maxFiles = 5, onSubmit }: MobileFileUploadComponentProps
 ) {
-    const [uploadedFileKeys, setUploadedFileKeys] = useState<string[]>([]);
+    const [uploadedFileNames, setUploadedFileNames] = useState<string[]>([]);
     const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
     const addFileKey = (fileKey: string) => {
-        setUploadedFileKeys(prevState => [...prevState, fileKey]);
+        setUploadedFileNames(prevState => [...prevState, fileKey]);
     };
 
     const deleteFileKey = (fileKey: string) => {
-        setUploadedFileKeys(prevState => prevState.filter(key => key !== fileKey));
+        setUploadedFileNames(prevState => prevState.filter(key => key !== fileKey));
     };
 
     const toggleDrawer = (open: boolean) => () => { setIsDrawerOpen(open); };
 
     const handleSubmit = () => {
-        if (onSubmit && uploadedFileKeys.length > 0) {
-            onSubmit(uploadedFileKeys);
+        if (onSubmit && uploadedFileNames.length > 0) {
+            onSubmit(uploadedFileNames);
         }
     };
 
@@ -50,7 +50,7 @@ export function MobileFileUploadComponent(
                             <MobileFileInputComponent 
                                 onTempFileUploaded={addFileKey} onTempFileDeleted={deleteFileKey}
                                 accept={accept} maxFiles={maxFiles} maxSize={maxSize}/>
-                            {onSubmit && uploadedFileKeys.length > 0 && (
+                            {onSubmit && uploadedFileNames.length > 0 && (
                                 <Button color="secondary" onClick={handleSubmit} sx={{ my: 1, width: '100%' }}>
                                     Submit
                                 </Button>

--- a/edukate-frontend/src/components/problem/SolutionCardComponent.tsx
+++ b/edukate-frontend/src/components/problem/SolutionCardComponent.tsx
@@ -28,14 +28,14 @@ export default function SolutionCardComponent({ problem, refreshProblem }: Solut
         }
     }, [submitFilesMutation.error]);
 
-    const handleSubmit = (fileKeys: string[]) => {
-        if (fileKeys.length === 0) {
+    const handleSubmit = (fileNames: string[]) => {
+        if (fileNames.length === 0) {
             setError('Please select at least one file to submit');
             return;
         }
 
         submitFilesMutation.mutate(
-            { problemId: problem.id, fileKeys },
+            { problemId: problem.id, fileNames },
             { onSuccess: () => {
                 setIsSuccess(true);
                 refreshProblem();

--- a/edukate-frontend/src/types/submission/CreateSubmissionRequest.ts
+++ b/edukate-frontend/src/types/submission/CreateSubmissionRequest.ts
@@ -1,4 +1,4 @@
 export type CreateSubmissionRequest = {
     problemId: string;
-    fileKeys: string[];
+    fileNames: string[];
 };

--- a/edukate-frontend/src/types/submission/Submission.ts
+++ b/edukate-frontend/src/types/submission/Submission.ts
@@ -1,8 +1,9 @@
 export interface Submission {
     problemId: string;
-    userId: string;
+    userName: string;
     status: SubmissionStatus;
-    createdAt: Date;
+    createdAt: string;
+    fileUrls: string[];
 }
 
-export type SubmissionStatus = "PENDING" | "SUCCESS" | "ERROR";
+export type SubmissionStatus = "PENDING" | "SUCCESS" | "FAILED";


### PR DESCRIPTION
This PR closes #17

### What's done:
 * Replaced `fileKeys` with `fileNames` in submission-related DTOs, functions, and entity models.
 * Updated backend services to process file objects and associate them with `fileObjectIds`.
 * Modified `SubmissionDto` to include `fileUrls` and adjusted file URL generation accordingly.
 * Refactored frontend components, including `FileUploadComponent` and `MobileFileUploadComponent`, to use `fileNames` instead of `fileKeys`.
 * Ensured seamless integration between submission handling on backend and frontend.