### PR TITLE
Switch Bundle to operate with user IDs instead of names

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/ProblemController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/ProblemController.java
@@ -45,8 +45,10 @@ public class ProblemController {
                     content = @Content(schema = @Schema(implementation = ProblemMetadata.class))),
     })
     @Parameters({
-            @Parameter(name = "page", description = "Page number (zero-based)", in = QUERY),
-            @Parameter(name = "size", description = "Number of problems per page", in = QUERY),
+            @Parameter(name = "page", description = "Page number (zero-based)", in = QUERY,
+                    schema = @Schema(minimum = "0")),
+            @Parameter(name = "size", description = "Number of problems per page", in = QUERY,
+                    schema = @Schema(minimum = "1", maximum = "100")),
     })
     public Flux<ProblemMetadata> getProblemList(
             @RequestParam(defaultValue = "0") int page,

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
@@ -171,8 +171,10 @@ public class SubmissionController {
                     content = @Content)
     })
     @Parameters({
-            @Parameter(name = "page", description = "Page number (zero-based)", in = QUERY),
-            @Parameter(name = "size", description = "Number of submissions per page", in = QUERY)
+            @Parameter(name = "page", description = "Page number (zero-based)", in = QUERY,
+                    schema = @Schema(minimum = "0")),
+            @Parameter(name = "size", description = "Number of submissions per page", in = QUERY,
+                    schema = @Schema(minimum = "1", maximum = "100")),
     })
     public Flux<SubmissionDto> getSubmissions(
             @RequestParam(defaultValue = "0") int page,

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/BundleDto.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/BundleDto.java
@@ -11,6 +11,7 @@ import java.util.List;
 public class BundleDto {
     private String name;
     private String description;
+    @With
     private List<String> admins;
     private Boolean isPublic;
     @With

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/BundleMetadata.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/BundleMetadata.java
@@ -2,6 +2,7 @@ package io.github.sanyavertolet.edukate.backend.dtos;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.With;
 
 import java.util.List;
 
@@ -10,6 +11,7 @@ import java.util.List;
 public class BundleMetadata {
     private String name;
     private String description;
+    @With
     private List<String> admins;
     private String shareCode;
     private Boolean isPublic;

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Bundle.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Bundle.java
@@ -7,6 +7,7 @@ import io.github.sanyavertolet.edukate.common.Role;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.With;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -26,107 +27,59 @@ public class Bundle {
     private Boolean isPublic;
 
     private List<String> problemIds;
-    private Map<String, Role> userRoles;
-    private Set<String> invitedUserNames;
+    private Map<String, Role> userIdRoleMap;
+    private Set<String> invitedUserIds;
 
     @Indexed(unique = true)
+    @With
     private String shareCode = null;
 
-    public Bundle updateShareCode(String shareCode) {
-        this.shareCode = shareCode;
-        return this;
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean addUser(String userId, Role role) {
+        return userIdRoleMap.putIfAbsent(userId, role) == null;
     }
 
-    public int addUser(String userName, Role role) {
-        if (!userRoles.containsKey(userName)) {
-            userRoles.put(userName, role);
-            return 1;
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean changeUserRole(String userId, Role newRole) {
+        if (!userIdRoleMap.containsKey(userId)) {
+            return false;
         }
-        return 0;
+        userIdRoleMap.put(userId, newRole);
+        return true;
     }
 
-    public int addUsers(Map<String, Role> usersWithRoles) {
-        return usersWithRoles.entrySet()
-                .stream()
-                .map(entry ->addUser(entry.getKey(), entry.getValue()))
-                .reduce(0, Integer::sum);
+    public Role getUserRole(String userId) {
+        return userIdRoleMap.getOrDefault(userId, null);
     }
 
-    public int changeUserRole(String userName, Role newRole) {
-        if (userRoles.containsKey(userName)) {
-            userRoles.put(userName, newRole);
-            return 1;
-        }
-        return 0;
+    public boolean isUserInBundle(String userId) {
+        return getUserRole(userId) != null;
     }
 
-    public Role getUserRole(String userName) {
-        return userRoles.getOrDefault(userName, null);
+    public boolean isUserInvited(String userId) {
+        return invitedUserIds.contains(userId);
     }
 
-    public boolean isUserInBundle(String userName) {
-        return getUserRole(userName) != null;
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean inviteUser(String userId) {
+        return invitedUserIds.add(userId);
     }
 
-    public boolean isUserInvited(String userName) {
-        return invitedUserNames != null && invitedUserNames.contains(userName);
+    public boolean removeInvitedUser(String userId) {
+        return invitedUserIds.remove(userId);
     }
 
-    public int inviteUser(String userName) {
-        if (invitedUserNames == null) {
-            invitedUserNames = new HashSet<>();
-        }
-        if (!invitedUserNames.contains(userName)) {
-            invitedUserNames.add(userName);
-            return 1;
-        }
-        return 0;
+    public boolean isAdmin(String userId) {
+        return Role.ADMIN.equals(getUserRole(userId));
     }
 
-    public int removeInvitedUser(String userName) {
-        return invitedUserNames != null && invitedUserNames.remove(userName) ? 1 : 0;
+    @SuppressWarnings("UnusedReturnValue")
+    public boolean removeUser(String userId) {
+        return userIdRoleMap.remove(userId) != null;
     }
 
-    public boolean isAdmin(String userName) {
-        return getUserRole(userName).equals(Role.ADMIN);
-    }
-
-    public int removeUser(String userName) {
-        return userRoles.remove(userName) != null ? 1 : 0;
-    }
-
-    public int removeUsers(List<String> userNames) {
-        return userNames.stream().map(this::removeUser).reduce(0, Integer::sum);
-    }
-
-    public int addProblem(String problemId) {
-        if (problemIds == null) {
-            problemIds = new ArrayList<>();
-        }
-        if (!problemIds.contains(problemId)) {
-            problemIds.add(problemId);
-            return 1;
-        }
-        return 0;
-    }
-
-    public int removeProblem(String problemId) {
-        return problemIds != null && problemIds.remove(problemId) ? 1 : 0;
-    }
-
-    public int addProblems(List<String> problemIds) {
-        return problemIds.stream().map(this::addProblem).reduce(0, Integer::sum);
-    }
-
-    public int removeProblems(List<String> problemIds) {
-        if (this.problemIds == null) {
-            return 0;
-        }
-        return problemIds.stream().map(this::removeProblem).reduce(0, Integer::sum);
-    }
-
-    public List<String> getAdmins() {
-        return userRoles.entrySet().stream().filter(entry -> entry.getValue().equals(Role.ADMIN))
+    public List<String> getAdminIds() {
+        return userIdRoleMap.entrySet().stream().filter(entry -> entry.getValue().equals(Role.ADMIN))
                 .map(Map.Entry::getKey).toList();
     }
 
@@ -135,19 +88,19 @@ public class Bundle {
                 null,
                 bundleRequest.getName(),
                 bundleRequest.getDescription(),
-                bundleRequest.getIsPublic(),
-                bundleRequest.getProblemIds(),
-                Map.of(adminId, Role.ADMIN),
-                Set.of(),
+                Boolean.TRUE.equals(bundleRequest.getIsPublic()),
+                new ArrayList<>(bundleRequest.getProblemIds() != null ? bundleRequest.getProblemIds() : List.of()),
+                new HashMap<>(Map.of(adminId, Role.ADMIN)),
+                new HashSet<>(),
                 null
         );
     }
 
     public BundleDto toDto() {
-        return new BundleDto(name, description, getAdmins(), isPublic, Collections.emptyList(), shareCode);
+        return new BundleDto(name, description, null, isPublic, null, shareCode);
     }
 
     public BundleMetadata toBundleMetadata() {
-        return new BundleMetadata(name, description, getAdmins(), shareCode, isPublic, (long) problemIds.size());
+        return new BundleMetadata(name, description, null, shareCode, isPublic, (long) problemIds.size());
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/BundleRepository.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/BundleRepository.java
@@ -17,6 +17,6 @@ public interface BundleRepository extends ReactiveMongoRepository<Bundle, String
 
     Mono<Bundle> findBundleByShareCode(String shareCode);
 
-    @Query("{ 'userRoles.?0': { $in: ?1 } }")
-    Flux<Bundle> findBundlesByUserRoleIn(String userName, Collection<Role> roles, Pageable pageable);
+    @Query("{ 'userIdRoleMap.?0': { $in: ?1 } }")
+    Flux<Bundle> findBundlesByUserRoleIn(String userId, Collection<Role> roles, Pageable pageable);
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/UserRepository.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/UserRepository.java
@@ -3,11 +3,14 @@ package io.github.sanyavertolet.edukate.backend.repositories;
 import io.github.sanyavertolet.edukate.common.entities.User;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.Collection;
 
 @Repository
 public interface UserRepository extends ReactiveMongoRepository<User, String> {
     Mono<User> findByName(String name);
 
-    Mono<Boolean> existsByName(String name);
+    Flux<User> findUsersByIdIn(Collection<String> ids);
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/UserService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/UserService.java
@@ -7,7 +7,10 @@ import io.github.sanyavertolet.edukate.common.utils.AuthUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,8 +25,12 @@ public class UserService {
         return userRepository.save(user);
     }
 
-    public Mono<User> findUserById(String name) {
-        return userRepository.findById(name);
+    public Mono<User> findUserById(String userId) {
+        return userRepository.findById(userId);
+    }
+
+    public Flux<User> findUsersByIds(List<String> userIds) {
+        return userRepository.findUsersByIdIn(userIds);
     }
 
     public Mono<User> findUserByName(String name) {
@@ -32,10 +39,6 @@ public class UserService {
 
     public Mono<Boolean> deleteUserById(String id) {
         return userRepository.deleteById(id).thenReturn(true).onErrorReturn(false);
-    }
-
-    public Mono<Boolean> doesUserExist(String username) {
-        return userRepository.existsByName(username);
     }
 
     public Mono<Boolean> hasUserPermissionToSubmit(User user) {

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/controllers/NotificationController.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/controllers/NotificationController.java
@@ -70,9 +70,11 @@ public class NotificationController {
         @ApiResponse(responseCode = "401", description = "Unauthorized", content = @Content),
     })
     @Parameters({
-            @Parameter(name = "size", description = "Number of notifications to retrieve per page", in = QUERY),
-            @Parameter(name = "page", description = "Page number (zero-based)", in = QUERY),
             @Parameter(name = "isRead", description = "Filter by read status (null for all notifications)", in = QUERY),
+            @Parameter(name = "page", description = "Page number (zero-based)", in = QUERY,
+                    schema = @Schema(minimum = "0")),
+            @Parameter(name = "size", description = "Number of notifications per page", in = QUERY,
+                    schema = @Schema(minimum = "1", maximum = "100")),
     })
     public Flux<BaseNotificationDto> getNotifications(
             @RequestParam(defaultValue = "10") Integer size,


### PR DESCRIPTION
### What's done:
 * Replaced all username-based logic with user ID in `BundleService` and related classes.
 * Updated authentication handling in `AuthUtils` to retrieve user ID instead of names.
 * Revised API endpoints in `BundleController` to utilize user ID for operations like joining, leaving, and inviting users.
 * Adjusted DTOs and entities, like `BundleMetadata`, to include admin user IDs and streamline query mappings.
 * Enhanced validation for user and bundle-related operations by working with user IDs.