### PR TITLE
Restrict allowed bundle share code characters

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/ShareCodeGenerator.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/ShareCodeGenerator.java
@@ -8,7 +8,7 @@ import java.security.SecureRandom;
 @Component
 @RequiredArgsConstructor
 public class ShareCodeGenerator {
-    private static final String ALLOWED_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    private static final String ALLOWED_CHARACTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     private static final int CODE_LENGTH = 10;
     private final SecureRandom random = new SecureRandom();
 


### PR DESCRIPTION
### What's done:
 * Removed `-` and `_` from `ALLOWED_CHARACTERS` in `ShareCodeGenerator` to limit share code character set.