### PR TITLE
Fix bundle join endpoint URL

### DIFF
--- a/edukate-frontend/src/http/requests.ts
+++ b/edukate-frontend/src/http/requests.ts
@@ -169,7 +169,7 @@ export function useJoinBundleMutation() {
                 return null;
             }
             try {
-                const response = await client.post<BundleMetadata>(`/api/v1/bundles/join/${bundleCode}`);
+                const response = await client.post<BundleMetadata>(`/api/v1/bundles/${bundleCode}/join`);
                 return response.data;
             } catch (error) {
                 throw defaultErrorHandler(error);


### PR DESCRIPTION
### What's done:
 * Changed the API endpoint in `requests.ts` to use `/api/v1/bundles/{bundleCode}/join` instead of `/api/v1/bundles/join/{bundleCode}`.