### PR TITLE
Add support for tracking problem submission statuses

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
@@ -78,7 +78,7 @@ public class SubmissionController {
                 .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Submission not found")))
                 .filter(submission -> submission.getUserId().equals(AuthUtils.id(authentication)))
                 .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied")))
-                .flatMap(submissionService::createSubmissionDto);
+                .flatMap(submissionService::prepareDto);
     }
 
     @PostMapping
@@ -127,7 +127,7 @@ public class SubmissionController {
                         )))
                         .then(submissionService.saveSubmission(submissionRequest, authentication))
                 )
-                .flatMap(submissionService::createSubmissionDto);
+                .flatMap(submissionService::prepareDto);
     }
 
     @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
@@ -165,7 +165,7 @@ public class SubmissionController {
                         submissionService.findSubmissionsByProblemIdAndUserId(
                                 problemId, user.getId(),
                                 PageRequest.of(page, size, Sort.Direction.DESC, "createdAt")))
-                .flatMap(submissionService::createSubmissionDto);
+                .flatMap(submissionService::prepareDto);
     }
 
     @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
@@ -194,6 +194,6 @@ public class SubmissionController {
                 List.of(Submission.Status.SUCCESS),
                 PageRequest.of(page, size, Sort.Direction.DESC, "createdAt")
         )
-                .flatMap(submissionService::createSubmissionDto);
+                .flatMap(submissionService::prepareDto);
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/internal/ProblemInternalController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/internal/ProblemInternalController.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.annotation.*;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
+import java.util.List;
+
 @Hidden
 @RestController
 @RequestMapping("/internal/problems")
@@ -21,17 +23,12 @@ public class ProblemInternalController {
     }
 
     @PostMapping("/batch")
-    public Flux<String> postProblemBatch(@RequestBody Flux<Problem> problems) {
+    public Flux<String> postProblemBatch(@RequestBody List<Problem> problems) {
         return problemService.updateProblemBatch(problems).map(Problem::getId);
     }
 
     @DeleteMapping("/{id}")
     public Mono<Boolean> deleteProblem(@PathVariable String id) {
         return problemService.deleteProblemById(id);
-    }
-
-    @PatchMapping("/missing-internal-indices")
-    public Mono<Long> updateMissingInternalIndices() {
-        return problemService.updateMissingInternalIndices();
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/ProblemDto.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/ProblemDto.java
@@ -4,6 +4,7 @@ import io.github.sanyavertolet.edukate.backend.entities.Problem;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.With;
 import org.springframework.data.annotation.PersistenceCreator;
 
 import java.util.ArrayList;
@@ -18,7 +19,9 @@ public class ProblemDto {
     private List<String> tags;
     private String text;
     private List<Problem.Subtask> subtasks = new ArrayList<>();
+    @With
     private List<String> images;
+    @With
     private Problem.Status status;
     private Boolean hasResult;
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/ProblemMetadata.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/ProblemMetadata.java
@@ -3,6 +3,7 @@ package io.github.sanyavertolet.edukate.backend.dtos;
 import io.github.sanyavertolet.edukate.backend.entities.Problem;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.With;
 import org.springframework.data.annotation.PersistenceCreator;
 
 import java.util.List;
@@ -13,5 +14,6 @@ public class ProblemMetadata {
     private String name;
     private Boolean isHard;
     private List<String> tags;
+    @With
     private Problem.Status status;
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/SubmissionDto.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/SubmissionDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.With;
 import org.springframework.data.annotation.PersistenceCreator;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -17,7 +17,7 @@ public class SubmissionDto {
     @With
     private String userName;
     private Submission.Status status;
-    private Instant createdAt;
+    private LocalDateTime createdAt;
     @With
     private List<String> fileUrls;
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Submission.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Submission.java
@@ -2,12 +2,13 @@ package io.github.sanyavertolet.edukate.backend.entities;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import java.time.Clock;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -20,7 +21,8 @@ public class Submission {
     private String userId;
     private Status status;
     private List<String> fileObjectIds;
-    private Instant createdAt;
+    @CreatedDate
+    private LocalDateTime createdAt;
 
     public enum Status {
         PENDING,
@@ -29,11 +31,6 @@ public class Submission {
     }
 
     public static Submission of(String problemId, String userId) {
-        return new Submission(null, problemId, userId, Status.PENDING, List.of(), Instant.now(Clock.systemUTC()));
-    }
-
-    public Submission markAs(Status status) {
-        this.status = status;
-        return this;
+        return new Submission(null, problemId, userId, Status.PENDING, List.of(), LocalDateTime.now(Clock.systemUTC()));
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/UserProblemStatus.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/UserProblemStatus.java
@@ -1,0 +1,28 @@
+package io.github.sanyavertolet.edukate.backend.entities;
+
+import lombok.Data;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+@Data
+@Document("problem_status")
+@CompoundIndex(name = "uniq_user_problem", def = "{ 'userId': 1, 'problemId': 1 }", unique = true)
+public class UserProblemStatus {
+    private String userId;
+
+    private String problemId;
+
+    private Submission.Status latestStatus;
+
+    private LocalDateTime latestTime;
+
+    private String latestSubmissionId;
+
+    private Submission.Status bestStatus;
+
+    private LocalDateTime bestTime;
+
+    private String bestSubmissionId;
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObject.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObject.java
@@ -10,7 +10,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.Instant;
+import java.time.LocalDateTime;
 
 @Data
 @Builder
@@ -33,10 +33,10 @@ public class FileObject {
     private FileObjectMetadata metadata;
 
     @CreatedDate
-    private Instant createdAt;
+    private LocalDateTime createdAt;
 
     @LastModifiedDate
-    private Instant updatedAt;
+    private LocalDateTime updatedAt;
 
     @Builder.Default
     private Integer metaVersion = 1;

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/listeners/ProblemBeforeSaveListener.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/listeners/ProblemBeforeSaveListener.java
@@ -1,17 +1,17 @@
-package io.github.sanyavertolet.edukate.backend.configs;
+package io.github.sanyavertolet.edukate.backend.listeners;
 
 import io.github.sanyavertolet.edukate.backend.entities.Problem;
 import io.github.sanyavertolet.edukate.backend.utils.SemVerUtils;
 import org.bson.Document;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
 import org.springframework.data.mongodb.core.mapping.event.BeforeSaveEvent;
+import org.springframework.stereotype.Component;
 import reactor.util.function.Tuple3;
 
 import java.util.Objects;
 
-@Configuration
-public class ProblemInsertionMongoEventListener extends AbstractMongoEventListener<Problem> {
+@Component
+public class ProblemBeforeSaveListener extends AbstractMongoEventListener<Problem> {
 
     @Override
     public void onBeforeSave(BeforeSaveEvent<Problem> event) {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/listeners/SubmissionAfterSaveListener.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/listeners/SubmissionAfterSaveListener.java
@@ -1,0 +1,107 @@
+package io.github.sanyavertolet.edukate.backend.listeners;
+
+import com.mongodb.client.model.UpdateOptions;
+import io.github.sanyavertolet.edukate.backend.entities.Submission;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+import org.springframework.data.mongodb.core.mapping.event.AbstractMongoEventListener;
+import org.springframework.data.mongodb.core.mapping.event.AfterSaveEvent;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Mono;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class SubmissionAfterSaveListener extends AbstractMongoEventListener<Submission> {
+    private static final String COLLECTION = "problem_status";
+    private final ReactiveMongoTemplate template;
+
+    @Override
+    public void onAfterSave(AfterSaveEvent<Submission> event) {
+        Submission s = event.getSource();
+        String userId = s.getUserId();
+        String problemId = s.getProblemId();
+        Submission.Status status = s.getStatus();
+        String submissionId = s.getId();
+
+        LocalDateTime createdAt = s.getCreatedAt();
+        if (createdAt == null) {
+            createdAt = LocalDateTime.now(Clock.systemUTC());
+        }
+
+        int newRank = switch (status) {
+            case SUCCESS -> 2;
+            case FAILED -> 1;
+            case PENDING -> 0;
+        };
+
+        Document filter = new Document("userId", userId).append("problemId", problemId);
+
+        List<Document> updatePipeline = List.of(
+                new Document("$set", new Document("userId", userId)
+                        .append("problemId", problemId)
+                        .append("latestStatus", status)
+                        .append("latestTime", createdAt)
+                        .append("latestSubmissionId", submissionId)
+                ),
+                new Document("$set", new Document("_prevBestRank", new Document("$ifNull", List.of("$bestRank", -1)))),
+                new Document("$set", new Document("_takeNewBest",
+                        new Document("$or", List.of(
+                                new Document("$gt", List.of(newRank, "$_prevBestRank")),
+                                new Document("$and", List.of(
+                                        new Document("$eq", List.of(newRank, "$_prevBestRank")),
+                                        new Document("$lt", List.of(
+                                                createdAt,
+                                                new Document("$ifNull", List.of("$bestTime", createdAt))
+                                        ))
+                                ))
+                        ))
+                )),
+                new Document("$set", new Document("bestRank",
+                        new Document("$cond", List.of(
+                                "$_takeNewBest",
+                                newRank,
+                                new Document("$ifNull", List.of("$bestRank", "$_prevBestRank"))
+                        ))
+                )),
+                new Document("$set", new Document("bestStatus",
+                        new Document("$cond", List.of(
+                                "$_takeNewBest",
+                                status,
+                                new Document("$ifNull", List.of("$bestStatus", status))
+                        ))
+                )),
+                new Document("$set", new Document("bestTime",
+                        new Document("$cond", List.of(
+                                "$_takeNewBest",
+                                createdAt,
+                                new Document("$ifNull", List.of("$bestTime", createdAt))
+                        ))
+                )),
+                new Document("$set", new Document("bestSubmissionId",
+                        new Document("$cond", List.of(
+                                "$_takeNewBest",
+                                submissionId,
+                                new Document("$ifNull", List.of("$bestSubmissionId", submissionId))
+                        ))
+                )),
+                new Document("$unset", List.of("_prevBestRank", "_takeNewBest"))
+        );
+
+        // todo: implement the duplicate-key retry
+        template.getMongoDatabase()
+            .flatMap(db -> Mono.from(
+                db.getCollection(COLLECTION)
+                    .updateOne(filter, updatePipeline, new UpdateOptions().upsert(true))
+            ))
+                .doOnSuccess(_ -> log.debug("problem_status upserted for submission {}", submissionId))
+                .doOnError(ex -> log.error("problem_status upsert failed for submission {}", submissionId, ex))
+                .subscribe();
+    }
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/UserProblemStatusRepository.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/UserProblemStatusRepository.java
@@ -1,0 +1,11 @@
+package io.github.sanyavertolet.edukate.backend.repositories;
+
+import io.github.sanyavertolet.edukate.backend.entities.UserProblemStatus;
+import io.github.sanyavertolet.edukate.common.repositories.ReactiveReadOnlyRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+@Repository
+public interface UserProblemStatusRepository extends ReactiveReadOnlyRepository<UserProblemStatus, String> {
+    Mono<UserProblemStatus> findByUserIdAndProblemId(String userId, String problemId);
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/ProblemStatusDecisionManager.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/ProblemStatusDecisionManager.java
@@ -1,0 +1,45 @@
+package io.github.sanyavertolet.edukate.backend.services;
+
+import io.github.sanyavertolet.edukate.backend.entities.Problem;
+import io.github.sanyavertolet.edukate.backend.entities.UserProblemStatus;
+import io.github.sanyavertolet.edukate.backend.repositories.UserProblemStatusRepository;
+import io.github.sanyavertolet.edukate.common.utils.AuthUtils;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@AllArgsConstructor
+public class ProblemStatusDecisionManager {
+    private final UserProblemStatusRepository userProblemStatusRepository;
+
+    public Mono<Problem.Status> getStatus(String userId, String problemId) {
+        return userProblemStatusRepository.findByUserIdAndProblemId(userId, problemId)
+                .flatMap(this::statusDecision)
+                .defaultIfEmpty(Problem.Status.NOT_SOLVED);
+    }
+
+    public Mono<Problem.Status> getStatus(String problemId, Authentication authentication) {
+        return AuthUtils.monoId(authentication)
+                .flatMap(userId -> getStatus(userId, problemId))
+                .defaultIfEmpty(Problem.Status.NOT_SOLVED);
+    }
+
+    /**
+     * bestStatus == Submission.Status.SUCCESS  =>  Problem.Status.SOLVED
+     * bestStatus == Submission.Status.FAILED   =>  Problem.Status.FAILED
+     * bestStatus == Submission.Status.PENDING  =>  Problem.Status.SOLVING
+     * else                                     =>  Problem.Status.NOT_SOLVED
+     */
+    private Mono<Problem.Status> statusDecision(UserProblemStatus userProblemStatus) {
+        return Mono.justOrEmpty(userProblemStatus)
+                .map(UserProblemStatus::getBestStatus)
+                .map(best -> switch (best) {
+                    case SUCCESS -> Problem.Status.SOLVED;
+                    case FAILED  -> Problem.Status.FAILED;
+                    case PENDING -> Problem.Status.SOLVING;
+                })
+                .defaultIfEmpty(Problem.Status.NOT_SOLVED);
+    }
+}

--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/repositories/ReactiveReadOnlyRepository.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/repositories/ReactiveReadOnlyRepository.java
@@ -1,0 +1,14 @@
+package io.github.sanyavertolet.edukate.common.repositories;
+
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.Repository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@NoRepositoryBean
+@SuppressWarnings("unused")
+public interface ReactiveReadOnlyRepository<T, ID> extends Repository<T, ID> {
+    Mono<T> findById(ID id);
+
+    Flux<T> findAll();
+}

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/controllers/NotificationController.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/controllers/NotificationController.java
@@ -30,8 +30,8 @@ import java.util.List;
 import static io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY;
 
 @Slf4j
-@RequiredArgsConstructor
 @RestController
+@RequiredArgsConstructor
 @Validated
 @RequestMapping("/api/v1/notifications")
 @Tag(name = "Notifications", description = "API for managing user notifications")
@@ -86,8 +86,8 @@ public class NotificationController {
                     schema = @Schema(minimum = "1", maximum = "100")),
     })
     public Flux<BaseNotificationDto> getNotifications(
-            @RequestParam(defaultValue = "10") @PositiveOrZero int size,
-            @RequestParam(defaultValue = "0") @Positive int page,
+            @RequestParam(defaultValue = "0") @PositiveOrZero int page,
+            @RequestParam(defaultValue = "10") @Positive int size,
             @RequestParam(required = false) Boolean isRead,
             Authentication authentication
     ) {


### PR DESCRIPTION
This PR closes #3 

### What's done:
 * Implemented `SubmissionAfterSaveListener` to update `problem_status` collection on submission persistence.
 * Added `UserProblemStatusRepository` for querying user-specific problem statuses.
 * Introduced `ProblemStatusDecisionManager` for determining problem statuses based on submission activity.
 * Refactored `SubmissionService`, `ProblemService`, and DTOs to improve status handling and populate necessary fields.
 * Updated `Submission` and related entities to use `LocalDateTime` for timestamps.
 * Removed unused status calculation logic from `SubmissionService`.
 * General cleanup of controllers and listeners to improve readability and separation of concerns.