### PR TITLE
Switch to `Instant` for timestamps across the application

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/UserController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/UserController.java
@@ -3,7 +3,6 @@ package io.github.sanyavertolet.edukate.backend.controllers;
 import io.github.sanyavertolet.edukate.backend.dtos.UserDto;
 import io.github.sanyavertolet.edukate.backend.services.UserService;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/FileMetadata.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/FileMetadata.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.With;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @AllArgsConstructor
@@ -12,10 +12,10 @@ public class FileMetadata {
     @With
     private String key;
     private String authorName;
-    private LocalDateTime lastModified;
+    private Instant lastModified;
     private Long size;
 
-    public static FileMetadata of(String key, String authorName, LocalDateTime lastModified, Long size) {
+    public static FileMetadata of(String key, String authorName, Instant lastModified, Long size) {
         return new FileMetadata(key, authorName, lastModified, size);
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/SubmissionDto.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/dtos/SubmissionDto.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import lombok.With;
 import org.springframework.data.annotation.PersistenceCreator;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Data
@@ -17,7 +17,7 @@ public class SubmissionDto {
     @With
     private String userName;
     private Submission.Status status;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     @With
     private List<String> fileUrls;
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Bundle.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Bundle.java
@@ -30,8 +30,8 @@ public class Bundle {
     private Map<String, Role> userIdRoleMap;
     private Set<String> invitedUserIds;
 
-    @Indexed(unique = true)
     @With
+    @Indexed(unique = true)
     private String shareCode = null;
 
     @SuppressWarnings("UnusedReturnValue")

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Submission.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Submission.java
@@ -1,18 +1,17 @@
 package io.github.sanyavertolet.edukate.backend.entities;
 
-import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
-@AllArgsConstructor(onConstructor = @__(@PersistenceCreator))
+@NoArgsConstructor
 @Document(value = "submissions")
 public class Submission {
     @Id
@@ -21,8 +20,9 @@ public class Submission {
     private String userId;
     private Status status;
     private List<String> fileObjectIds;
+
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     public enum Status {
         PENDING,
@@ -30,7 +30,14 @@ public class Submission {
         FAILED
     }
 
+    public Submission(String problemId, String userId) {
+        this.problemId = problemId;
+        this.userId = userId;
+        this.status = Status.PENDING;
+        this.fileObjectIds = new ArrayList<>();
+    }
+
     public static Submission of(String problemId, String userId) {
-        return new Submission(null, problemId, userId, Status.PENDING, List.of(), LocalDateTime.now(Clock.systemUTC()));
+        return new Submission(problemId, userId);
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/UserProblemStatus.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/UserProblemStatus.java
@@ -4,7 +4,7 @@ import lombok.Data;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Document("problem_status")
@@ -16,13 +16,13 @@ public class UserProblemStatus {
 
     private Submission.Status latestStatus;
 
-    private LocalDateTime latestTime;
+    private Instant latestTime;
 
     private String latestSubmissionId;
 
     private Submission.Status bestStatus;
 
-    private LocalDateTime bestTime;
+    private Instant bestTime;
 
     private String bestSubmissionId;
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObject.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileObject.java
@@ -10,7 +10,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Builder
@@ -33,10 +33,10 @@ public class FileObject {
     private FileObjectMetadata metadata;
 
     @CreatedDate
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 
     @LastModifiedDate
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
 
     @Builder.Default
     private Integer metaVersion = 1;

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/listeners/SubmissionAfterSaveListener.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/listeners/SubmissionAfterSaveListener.java
@@ -3,6 +3,7 @@ package io.github.sanyavertolet.edukate.backend.listeners;
 import com.mongodb.client.model.UpdateOptions;
 import io.github.sanyavertolet.edukate.backend.entities.Submission;
 import lombok.AllArgsConstructor;
+import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
 import org.bson.Document;
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
@@ -12,7 +13,7 @@ import org.springframework.stereotype.Component;
 import reactor.core.publisher.Mono;
 
 import java.time.Clock;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 
 @Slf4j
@@ -23,16 +24,16 @@ public class SubmissionAfterSaveListener extends AbstractMongoEventListener<Subm
     private final ReactiveMongoTemplate template;
 
     @Override
-    public void onAfterSave(AfterSaveEvent<Submission> event) {
+    public void onAfterSave(@NonNull AfterSaveEvent<Submission> event) {
         Submission s = event.getSource();
         String userId = s.getUserId();
         String problemId = s.getProblemId();
         Submission.Status status = s.getStatus();
         String submissionId = s.getId();
 
-        LocalDateTime createdAt = s.getCreatedAt();
+        Instant createdAt = s.getCreatedAt();
         if (createdAt == null) {
-            createdAt = LocalDateTime.now(Clock.systemUTC());
+            createdAt = Instant.now(Clock.systemUTC());
         }
 
         int newRank = switch (status) {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/BundleService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/BundleService.java
@@ -157,7 +157,7 @@ public class BundleService {
     }
 
     @Transactional
-    public Mono<Bundle> changeVisibility(String shareCode, Boolean isPublic, Authentication authentication) {
+    public Mono<Bundle> changeVisibility(String shareCode, boolean isPublic, Authentication authentication) {
         return findBundleByShareCode(shareCode)
                 .filter(bundle -> bundlePermissionEvaluator.hasRole(bundle, Role.MODERATOR, authentication))
                 .switchIfEmpty(Mono.error(new ResponseStatusException(

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/UserService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/UserService.java
@@ -42,6 +42,6 @@ public class UserService {
     }
 
     public Mono<Boolean> hasUserPermissionToSubmit(User user) {
-        return Mono.just(user).filter(usr -> usr.getStatus().equals(UserStatus.ACTIVE)).hasElement();
+        return Mono.just(user).filter(usr -> UserStatus.ACTIVE.equals(usr.getStatus())).hasElement();
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/BaseFileService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/BaseFileService.java
@@ -13,8 +13,6 @@ import reactor.util.function.Tuples;
 
 import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.List;
 
 @Slf4j
@@ -79,9 +77,7 @@ public class BaseFileService {
                 .map(fo -> FileMetadata.of(
                         fo.getKey() != null ? fo.getKey().getFileName() : fo.getKeyPath(),
                         authorName,
-                        fo.getMetadata() != null && fo.getMetadata().getLastModified() != null
-                                ? LocalDateTime.ofInstant(fo.getMetadata().getLastModified(), ZoneId.systemDefault())
-                                : null,
+                        fo.getMetadata() != null ? fo.getMetadata().getLastModified() : null,
                         fo.getMetadata() != null ? fo.getMetadata().getContentLength() : null
                 ));
     }

--- a/edukate-backend/src/main/resources/application.properties
+++ b/edukate-backend/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.application.name=edukate
 spring.codec.max-in-memory-size=100MB
 spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI}
+spring.data.mongodb.auto-index-creation=true
 spring.liquibase.enabled=false
 server.port=5800
 

--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/notifications/BaseNotificationCreateRequest.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/notifications/BaseNotificationCreateRequest.java
@@ -29,9 +29,7 @@ public sealed class BaseNotificationCreateRequest permits
 
     @PersistenceCreator
     public BaseNotificationCreateRequest(String uuid, String targetUserId) {
-        Objects.requireNonNull(uuid, "UUID must not be null");
-        Objects.requireNonNull(targetUserId, "userId must not be null");
-        this.uuid = uuid;
-        this.targetUserId = targetUserId;
+        this.uuid = Objects.requireNonNull(uuid, "UUID must not be null");
+        this.targetUserId = Objects.requireNonNull(targetUserId, "userId must not be null");
     }
 }

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/configs/MongoConfig.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/configs/MongoConfig.java
@@ -1,0 +1,8 @@
+package io.github.sanyavertolet.edukate.notifier.configs;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableReactiveMongoAuditing;
+
+@Configuration
+@EnableReactiveMongoAuditing
+public class MongoConfig { }

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/dtos/BaseNotificationDto.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/dtos/BaseNotificationDto.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @JsonTypeInfo(
         use = JsonTypeInfo.Id.NAME,
@@ -22,5 +22,5 @@ import java.time.LocalDateTime;
 public sealed class BaseNotificationDto permits SimpleNotificationDto, InviteNotificationDto {
     private String uuid;
     private Boolean isRead;
-    private LocalDateTime createdAt;
+    private Instant createdAt;
 }

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/dtos/InviteNotificationDto.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/dtos/InviteNotificationDto.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Getter;
 import lombok.Setter;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -15,7 +15,7 @@ public final class InviteNotificationDto extends BaseNotificationDto {
     private String bundleShareCode;
 
     public InviteNotificationDto(
-            String uuid, Boolean isRead, LocalDateTime createdAt, String inviterName, String bundleName,
+            String uuid, Boolean isRead, Instant createdAt, String inviterName, String bundleName,
             String bundleShareCode
     ) {
         super(uuid, isRead, createdAt);

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/dtos/SimpleNotificationDto.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/dtos/SimpleNotificationDto.java
@@ -3,7 +3,7 @@ package io.github.sanyavertolet.edukate.notifier.dtos;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -14,7 +14,7 @@ public final class SimpleNotificationDto extends BaseNotificationDto {
     private String source;
 
     public SimpleNotificationDto(
-            String uuid, Boolean isRead, LocalDateTime createdAt,
+            String uuid, Boolean isRead, Instant createdAt,
             String title, String message, String source
     ) {
         super(uuid, isRead, createdAt);

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/BaseNotification.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/BaseNotification.java
@@ -7,16 +7,16 @@ import io.github.sanyavertolet.edukate.common.notifications.BaseNotificationCrea
 import io.github.sanyavertolet.edukate.common.notifications.InviteNotificationCreateRequest;
 import io.github.sanyavertolet.edukate.common.notifications.SimpleNotificationCreateRequest;
 import io.github.sanyavertolet.edukate.notifier.dtos.BaseNotificationDto;
-import lombok.AllArgsConstructor;
 import lombok.Data;
-import org.bson.types.ObjectId;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Document(collection = "notifications")
@@ -33,19 +33,27 @@ import java.time.LocalDateTime;
 })
 @JsonTypeName("base")
 @TypeAlias("base")
-@AllArgsConstructor(onConstructor = @__(@PersistenceCreator))
+@NoArgsConstructor
 public sealed class BaseNotification permits SimpleNotification, InviteNotification {
     @Id
-    private ObjectId _id;
+    private String _id;
 
     @Indexed(unique = true)
     private String uuid;
 
+    @NonNull
     private Boolean isRead;
 
     private String targetUserId;
 
-    private LocalDateTime createdAt;
+    @CreatedDate
+    private Instant createdAt;
+
+    public BaseNotification(String uuid, String targetUserId) {
+        this.uuid = uuid;
+        this.targetUserId = targetUserId;
+        this.isRead = false;
+    }
 
     public static BaseNotification fromCreationRequest(BaseNotificationCreateRequest creationRequest) {
         if (creationRequest instanceof SimpleNotificationCreateRequest simpleNotificationCreationRequest) {

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/InviteNotification.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/InviteNotification.java
@@ -4,44 +4,27 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.github.sanyavertolet.edukate.common.notifications.InviteNotificationCreateRequest;
 import io.github.sanyavertolet.edukate.notifier.dtos.InviteNotificationDto;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.bson.types.ObjectId;
-import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.TypeAlias;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @TypeAlias("invite")
 @JsonTypeName("invite")
 public final class InviteNotification extends BaseNotification {
-    private final String inviterName;
-    private final String bundleName;
-    private final String bundleShareCode;
-
-    @PersistenceCreator
-    public InviteNotification(
-            ObjectId _id, String uuid, String targetUserId, LocalDateTime createdAt,
-            String inviterName, String bundleName, String bundleShareCode
-    ) {
-        this(_id, uuid, false, targetUserId, createdAt, inviterName, bundleName, bundleShareCode);
-    }
-
-    public InviteNotification(
-            ObjectId _id, String uuid, Boolean isRead, String targetUserId,
-            LocalDateTime createdAt, String inviterName, String bundleName, String bundleShareCode
-    ) {
-        super(_id, uuid, isRead, targetUserId, createdAt != null ? createdAt : LocalDateTime.now());
-        this.inviterName = inviterName;
-        this.bundleName = bundleName;
-        this.bundleShareCode = bundleShareCode;
-    }
+    private String inviterName;
+    private String bundleName;
+    private String bundleShareCode;
 
     public InviteNotification(
             String uuid, String targetUserId, String inviterName, String bundleName, String bundleShareCode
     ) {
-        this(null, uuid, targetUserId, LocalDateTime.now(), inviterName, bundleName, bundleShareCode);
+        super(uuid, targetUserId);
+        this.inviterName = inviterName;
+        this.bundleName = bundleName;
+        this.bundleShareCode = bundleShareCode;
     }
 
     @Override

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/SimpleNotification.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/SimpleNotification.java
@@ -4,42 +4,25 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import io.github.sanyavertolet.edukate.common.notifications.SimpleNotificationCreateRequest;
 import io.github.sanyavertolet.edukate.notifier.dtos.SimpleNotificationDto;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.bson.types.ObjectId;
-import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.annotation.TypeAlias;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @TypeAlias("simple")
 @JsonTypeName("simple")
 public final class SimpleNotification extends BaseNotification {
-    private final String title;
-    private final String message;
-    private final String source;
+    private String title;
+    private String message;
+    private String source;
 
-    @PersistenceCreator
-    public SimpleNotification(
-            ObjectId _id, String uuid, String targetUserId, LocalDateTime createdAt, String title, String message,
-            String source
-    ) {
-        this(_id, uuid, false, targetUserId, createdAt, title, message, source);
-    }
-
-    public SimpleNotification(
-            ObjectId _id, String uuid, Boolean isRead, String targetUserId,
-            LocalDateTime createdAt, String title, String message, String source
-    ) {
-        super(_id, uuid, isRead, targetUserId, createdAt != null ? createdAt : LocalDateTime.now());
+    public SimpleNotification(String uuid, String targetUserId, String title, String message, String source) {
+        super(uuid, targetUserId);
         this.title = title;
         this.message = message;
         this.source = source;
-    }
-
-    public SimpleNotification(String uuid, String targetUserId, String title, String message, String source) {
-        this(null, uuid, targetUserId, LocalDateTime.now(), title, message, source);
     }
 
     @Override

--- a/edukate-notifier/src/main/resources/application.properties
+++ b/edukate-notifier/src/main/resources/application.properties
@@ -1,6 +1,7 @@
 spring.application.name=edukate-notifier
 spring.docker.compose.enabled=false
 spring.data.mongodb.uri=${SPRING_DATA_MONGODB_URI}
+spring.data.mongodb.auto-index-creation=true
 server.port=5820
 
 management.server.port=5821


### PR DESCRIPTION
### What's done:
 * Replaced `LocalDateTime` with `Instant` for timestamp fields in multiple entities and DTOs.
 * Updated `onAfterSave` method in `SubmissionAfterSaveListener` to handle `Instant`.
 * Refactored factory methods and constructors to accommodate `Instant` usage.
 * Introduced `MongoConfig` for enabling reactive Mongo auditing with `@CreatedDate`.
 * Set `spring.data.mongodb.auto-index-creation=true` in configuration files.
 * Removed redundant use of `LocalDateTime` transformation logic in services.