### PR TITLE
Refactor date utilities and standardize date types on frontend

### DIFF
--- a/edukate-frontend/src/components/notifications/InviteNotificationComponent.tsx
+++ b/edukate-frontend/src/components/notifications/InviteNotificationComponent.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { Avatar, Badge, Box, Stack, Typography } from "@mui/material";
 import { InviteNotification } from "../../types/notification/InviteNotification";
-import { formatDate } from "../../utils/utils";
+import { formatDate } from "../../utils/date";
 
 interface InviteNotificationComponentProps {
     notification: InviteNotification;

--- a/edukate-frontend/src/components/notifications/SimpleNotificationComponent.tsx
+++ b/edukate-frontend/src/components/notifications/SimpleNotificationComponent.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
 import { Avatar, Badge, Box, Stack, Typography } from "@mui/material";
 import { SimpleNotification } from "../../types/notification/SimpleNotification";
-import { formatDate } from "../../utils/utils";
+import { formatDate } from "../../utils/date";
 
 interface SimpleNotificationComponentProps {
     notification: SimpleNotification;
@@ -15,7 +15,7 @@ export const SimpleNotificationComponent: FC<SimpleNotificationComponentProps> =
             </Badge>
             <Box>
                 <Typography component={"span"} variant={"h6"} textAlign={"center"}>
-                    {notification.title}
+                    { notification.title }
                 </Typography>
                 <Box>
                     <Box>

--- a/edukate-frontend/src/hooks/useFileUpload.ts
+++ b/edukate-frontend/src/hooks/useFileUpload.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, ChangeEvent } from "react";
 import { usePostTempFileMutation, useDeleteTempFileMutation, useGetTempFiles } from "../http/files";
 import { FileMetadata } from "../types/file/FileMetadata";
 import { formatFileSize } from "../utils/utils";
+import { nowUtcIso } from "../utils/date";
 
 type UseFileUploadProps = {
     onTempFileUploaded: (fileKey: string) => void;
@@ -66,7 +67,7 @@ export const useFileUpload = ({
         const newFiles: FileMetadata[] = Array.from(event.target.files).map(file => ({
             key: file.name,
             authorName: '',
-            lastModified: new Date().toISOString(),
+            lastModified: nowUtcIso(),
             size: file.size,
             status: 'pending',
             progress: 0,

--- a/edukate-frontend/src/types/common/DateTypes.ts
+++ b/edukate-frontend/src/types/common/DateTypes.ts
@@ -1,0 +1,1 @@
+export type UtcIsoString = string;

--- a/edukate-frontend/src/types/file/FileMetadata.ts
+++ b/edukate-frontend/src/types/file/FileMetadata.ts
@@ -1,7 +1,9 @@
+import { UtcIsoString } from "../common/DateTypes";
+
 export interface FileMetadata {
     key: string;
     authorName: string;
-    lastModified: string;
+    lastModified: UtcIsoString;
     size: number;
 
     status?: 'pending' | 'uploading' | 'success' | 'error';

--- a/edukate-frontend/src/types/notification/BaseNotification.ts
+++ b/edukate-frontend/src/types/notification/BaseNotification.ts
@@ -1,7 +1,9 @@
+import { UtcIsoString } from "../common/DateTypes";
+
 export interface BaseNotification {
     "_type": "base" | "simple" | "invite";
     uuid: string;
     userId: string;
     isRead: boolean;
-    createdAt: Date;
+    createdAt: UtcIsoString;
 }

--- a/edukate-frontend/src/types/submission/Submission.ts
+++ b/edukate-frontend/src/types/submission/Submission.ts
@@ -1,8 +1,10 @@
+import { UtcIsoString } from "../common/DateTypes";
+
 export interface Submission {
     problemId: string;
     userName: string;
     status: SubmissionStatus;
-    createdAt: string;
+    createdAt: UtcIsoString;
     fileUrls: string[];
 }
 

--- a/edukate-frontend/src/utils/date.ts
+++ b/edukate-frontend/src/utils/date.ts
@@ -1,0 +1,72 @@
+import { UtcIsoString } from "../types/common/DateTypes";
+
+export type DateInput = Date | UtcIsoString | number;
+
+export function isUtcIsoString(value: unknown): value is UtcIsoString {
+    return (
+        typeof value === "string" &&
+        /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$/.test(value)
+    );
+}
+
+export function parseDate(input: DateInput): Date {
+    if (input instanceof Date) return input;
+    if (typeof input === "number") return new Date(input);
+    const d = new Date(input);
+    if (isNaN(d.getTime())) {
+        throw new Error(`Invalid date input: ${String(input)}`);
+    }
+    return d;
+}
+
+export type FormatDateOptions = {
+    locale?: string;
+    timeZone?: 'local' | 'utc';
+    dateStyle?: 'full' | 'long' | 'medium' | 'short';
+    timeStyle?: 'full' | 'long' | 'medium' | 'short' | 'none';
+};
+
+export function formatDate(input: DateInput, opts: FormatDateOptions = {}): string {
+    const { locale, timeZone = 'local', dateStyle = 'medium', timeStyle = 'short' } = opts;
+
+    const d = parseDate(input);
+    const tz = timeZone === 'utc' ? 'UTC' : undefined;
+
+    if (timeStyle === 'none') {
+        return new Intl.DateTimeFormat(locale, { dateStyle, timeZone: tz }).format(d);
+    }
+    return new Intl.DateTimeFormat(locale, { dateStyle, timeStyle, timeZone: tz }).format(d);
+}
+
+export function formatRelative(input: DateInput, locale?: string): string {
+    const d = parseDate(input).getTime();
+    const now = Date.now();
+    const diff = d - now;
+
+    const rtf = new Intl.RelativeTimeFormat(locale, { numeric: 'auto' });
+
+    const absDiff = Math.abs(diff);
+    const minutes = Math.round(diff / (60_000));
+    if (absDiff < 60_000) return rtf.format(Math.round(diff / 1000), 'second');
+    if (absDiff < 3_600_000) return rtf.format(minutes, 'minute');
+
+    const hours = Math.round(diff / 3_600_000);
+    if (absDiff < 86_400_000) return rtf.format(hours, 'hour');
+
+    const days = Math.round(diff / 86_400_000);
+    if (absDiff < 30 * 86_400_000) return rtf.format(days, 'day');
+
+    const months = Math.round(diff / (30 * 86_400_000));
+    if (absDiff < 365 * 86_400_000) return rtf.format(months, 'month');
+
+    const years = Math.round(diff / (365 * 86_400_000));
+    return rtf.format(years, 'year');
+}
+
+export function nowUtcIso(): UtcIsoString {
+    return new Date().toISOString();
+}
+
+export function toUtcIso(input: DateInput): UtcIsoString {
+    return parseDate(input).toISOString();
+}

--- a/edukate-frontend/src/utils/utils.ts
+++ b/edukate-frontend/src/utils/utils.ts
@@ -62,10 +62,3 @@ export function getColorByStringHash(str: string) {
     }
     return colors[Math.abs(hash) % colors.length];
 }
-
-export function formatDate(date: Date) {
-    const d = new Date(date);
-    return d.toLocaleDateString('en-US', {
-        month: 'short', day: '2-digit', year: 'numeric', hour: '2-digit', minute: '2-digit'
-    });
-}


### PR DESCRIPTION
### What's done:
 * Introduced `DateTypes.ts` to define `UtcIsoString` type, centralizing date-related typing.
 * Moved and refactored date formatting utilities to `date.ts` for better modularity.
 * Updated various components, hooks, and types (`FileMetadata`, `BaseNotification`, `Submission`) to use `UtcIsoString` instead of `string` or `Date` for date fields.
 * Replaced redundant `formatDate` usage in `utils.ts` with the new implementations in `date.ts`.