### PR TITLE
Remove `@TypeAlias` annotations and adjust submission ordering

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.java
@@ -165,11 +165,11 @@ public class SubmissionController {
                         submissionService.findSubmissionsByProblemIdAndUserId(
                                 problemId, user.getId(),
                                 PageRequest.of(page, size, Sort.Direction.DESC, "createdAt")))
-                .flatMap(submissionService::prepareDto);
+                .flatMapSequential(submissionService::prepareDto);
     }
 
     @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
-    @GetMapping
+    @GetMapping("/all")
     @Operation(
             summary = "Get all successful submissions",
             description = "Retrieves paginated list of all submissions with SUCCESS status"

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/FileKey.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.Getter;
 import lombok.ToString;
-import org.springframework.data.annotation.TypeAlias;
 
 import java.util.Arrays;
 
@@ -23,7 +22,6 @@ import java.util.Arrays;
 })
 @ToString
 @JsonTypeName("base")
-@TypeAlias("base")
 abstract public class FileKey {
     @Getter
     protected String fileName;

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ProblemFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ProblemFileKey.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.data.annotation.PersistenceCreator;
-import org.springframework.data.annotation.TypeAlias;
 
-@TypeAlias("problem")
 @JsonTypeName("problem")
 @EqualsAndHashCode(callSuper = true, of = {"problemId"})
 public class ProblemFileKey extends FileKey {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ResultFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/ResultFileKey.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.data.annotation.PersistenceCreator;
-import org.springframework.data.annotation.TypeAlias;
 
-@TypeAlias("result")
 @JsonTypeName("result")
 @EqualsAndHashCode(callSuper = true, of = {"problemId"})
 public class ResultFileKey extends FileKey {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/SubmissionFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/SubmissionFileKey.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.data.annotation.PersistenceCreator;
-import org.springframework.data.annotation.TypeAlias;
 
-@TypeAlias("submission")
 @JsonTypeName("submission")
 @EqualsAndHashCode(callSuper = true, of = {"userId", "problemId", "submissionId"})
 public class SubmissionFileKey extends FileKey {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/TempFileKey.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/files/TempFileKey.java
@@ -4,9 +4,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.springframework.data.annotation.PersistenceCreator;
-import org.springframework.data.annotation.TypeAlias;
 
-@TypeAlias("tmp")
 @JsonTypeName("tmp")
 @EqualsAndHashCode(callSuper = true, of = {"userId"})
 public class TempFileKey extends FileKey {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/SubmissionService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/SubmissionService.java
@@ -76,7 +76,7 @@ public class SubmissionService {
         ))
                 .flatMap(dto -> fileObjectRepository.findAllById(submission.getFileObjectIds())
                         .map(FileObject::getKey)
-                        .flatMap(baseFileService::getDownloadUrlOrEmpty)
+                        .flatMapSequential(baseFileService::getDownloadUrlOrEmpty)
                         .collectList()
                         .map(dto::withFileUrls)
                 )

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/BaseNotification.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/BaseNotification.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 
@@ -32,7 +31,6 @@ import java.time.Instant;
         @JsonSubTypes.Type(value = InviteNotification.class, name = "invite")
 })
 @JsonTypeName("base")
-@TypeAlias("base")
 @NoArgsConstructor
 public sealed class BaseNotification permits SimpleNotification, InviteNotification {
     @Id

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/InviteNotification.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/InviteNotification.java
@@ -6,12 +6,10 @@ import io.github.sanyavertolet.edukate.notifier.dtos.InviteNotificationDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.TypeAlias;
 
 @Getter
 @Setter
 @NoArgsConstructor
-@TypeAlias("invite")
 @JsonTypeName("invite")
 public final class InviteNotification extends BaseNotification {
     private String inviterName;

--- a/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/SimpleNotification.java
+++ b/edukate-notifier/src/main/java/io/github/sanyavertolet/edukate/notifier/entities/SimpleNotification.java
@@ -6,12 +6,10 @@ import io.github.sanyavertolet.edukate.notifier.dtos.SimpleNotificationDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.springframework.data.annotation.TypeAlias;
 
 @Getter
 @Setter
 @NoArgsConstructor
-@TypeAlias("simple")
 @JsonTypeName("simple")
 public final class SimpleNotification extends BaseNotification {
     private String title;


### PR DESCRIPTION
### What's done:
 * Removed unused `@TypeAlias` annotations across multiple entity classes (`FileKey`, `ProblemFileKey`, `ResultFileKey`, `SubmissionFileKey`, `TempFileKey`, `BaseNotification`, etc.) for cleaner code.
 * Updated `SubmissionService` to use `.flatMapSequential()` instead of `.flatMap()` for file URL mapping.
 * Adjusted submission controller endpoint, changing `/` to `/all` for retrieving all submissions.