### PR TITLE
Add random unsolved problem retrieval functionality on backend

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/ProblemController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/ProblemController.java
@@ -44,8 +44,8 @@ public class ProblemController {
             description = "Retrieves a paginated list of problem metadata"
     )
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Successfully retrieved problem list",
-                    content = @Content(schema = @Schema(implementation = ProblemMetadata.class))),
+            @ApiResponse(responseCode = "200", description = "Successfully retrieved problem list", content = @Content(
+                    array = @ArraySchema(schema = @Schema(implementation = ProblemMetadata.class)))),
             @ApiResponse(responseCode = "400", description = "Validation failed", content = @Content)
     })
     @Parameters({
@@ -120,5 +120,22 @@ public class ProblemController {
         return problemService.findProblemById(id)
                 .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Problem not found")))
                 .flatMap(problem -> problemService.prepareDto(problem, authentication));
+    }
+
+    @GetMapping("/random")
+    @Operation(
+            summary = "Get random problem ID",
+            description = "Returns a random problem ID. If the user is authenticated, prioritizes problems" +
+                    "the user hasn't solved yet; otherwise returns any random problem."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Successfully retrieved random problem ID",
+                    content = @Content(mediaType = "text/plain", schema = @Schema(implementation = String.class))
+            )
+    })
+    public Mono<String> getRandomUnsolvedProblemId(Authentication authentication) {
+        return problemService.getRandomUnsolvedProblemId(authentication);
     }
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/ProblemRepository.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/ProblemRepository.java
@@ -2,10 +2,12 @@ package io.github.sanyavertolet.edukate.backend.repositories;
 
 import io.github.sanyavertolet.edukate.backend.entities.Problem;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.Aggregation;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 import java.util.Collection;
 
@@ -18,9 +20,19 @@ public interface ProblemRepository extends ReactiveMongoRepository<Problem, Stri
 
     Flux<Problem> findProblemsByIdStartingWith(String prefix, Pageable pageable);
 
-    @Query("{ $or: [" +
-            "{ majorId: { $exists: false } }," +
-            "{ minorId: { $exists: false } }," +
-            "{ patchId: { $exists: false } }] }")
-    Flux<Problem> findProblemsWithMissingIndices();
+    @Aggregation(pipeline = {
+            "{ $lookup: { from: 'problem_status', let: { pid: '$_id' }, pipeline: [" +
+                    "{ $match: { $expr: { $and: [ { $eq: ['$problemId', '$$pid'] }, " +
+                    "{ $eq: ['$userId', ?0] } ] } } } ], as: 'ps' } }",
+            "{ $match: { ps: { $size: 0 } } }",
+            "{ $sample: { size: 1 } }",
+            "{ $project: { _id: 0, id: '$_id' } }"
+    })
+    Mono<String> findRandomUnsolvedProblemId(String userId);
+
+    @Aggregation(pipeline = {
+            "{ $sample: { size: 1 } }",
+            "{ $project: { _id: 0, id: '$_id' } }"
+    })
+    Mono<String> findRandomProblemId();
 }

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/ProblemService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/ProblemService.java
@@ -7,10 +7,12 @@ import io.github.sanyavertolet.edukate.backend.entities.files.ProblemFileKey;
 import io.github.sanyavertolet.edukate.backend.repositories.ProblemRepository;
 import io.github.sanyavertolet.edukate.backend.services.files.BaseFileService;
 import io.github.sanyavertolet.edukate.backend.utils.Sorts;
+import io.github.sanyavertolet.edukate.common.utils.AuthUtils;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.lang.Nullable;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import reactor.core.publisher.Flux;
@@ -57,6 +59,12 @@ public class ProblemService {
     public Flux<String> getProblemIdsByPrefix(@NonNull String prefix, int limit) {
         return problemRepository.findProblemsByIdStartingWith(prefix, Pageable.ofSize(limit))
                 .map(Problem::getId);
+    }
+
+    public Mono<String> getRandomUnsolvedProblemId(@Nullable Authentication authentication) {
+        return AuthUtils.monoId(authentication)
+                .flatMap(problemRepository::findRandomUnsolvedProblemId)
+                .switchIfEmpty(problemRepository.findRandomProblemId());
     }
 
     public Mono<ProblemDto> prepareDto(@NonNull Problem problem, Authentication authentication) {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/utils/SemVerUtils.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/utils/SemVerUtils.java
@@ -1,30 +1,11 @@
 package io.github.sanyavertolet.edukate.backend.utils;
 
-import io.github.sanyavertolet.edukate.backend.repositories.ProblemRepository;
 import reactor.util.function.Tuple3;
 import reactor.util.function.Tuples;
 
 public final class SemVerUtils {
-
-    /**
-     * Warning: changing this field will destroy the sorting logic.
-     *
-     * @see ProblemRepository#findProblemsWithMissingIndices
-     */
     public static String majorFieldName = "majorId";
-
-    /**
-     * Warning: changing this field will destroy the sorting logic.
-     *
-     * @see ProblemRepository#findProblemsWithMissingIndices
-     */
     public static String minorFieldName = "minorId";
-
-    /**
-     * Warning: changing this field will destroy the sorting logic.
-     *
-     * @see ProblemRepository#findProblemsWithMissingIndices
-     */
     public static String patchFieldName = "patchId";
 
     private SemVerUtils() { }


### PR DESCRIPTION
### What's done:
 * Added method `getRandomUnsolvedProblemId` in `ProblemService` to retrieve a random problem ID with prioritization for unsolved problems if user is authenticated.
 * Introduced API endpoint `/random` in `ProblemController` to expose the random problem ID retrieval functionality.
 * Added repository methods `findRandomUnsolvedProblemId` and `findRandomProblemId` in `ProblemRepository` using MongoDB aggregation pipelines.
 * Updated API documentation in `ProblemController` for the new endpoint.
 * Removed redundant comments from `SemVerUtils`.