### PR TITLE
Center-align headers and adjust Paper layout in bundle tabs

### DIFF
--- a/edukate-frontend/src/components/bundle/BundleDescriptionTabComponent.tsx
+++ b/edukate-frontend/src/components/bundle/BundleDescriptionTabComponent.tsx
@@ -8,9 +8,11 @@ interface BundleDescriptionTabComponentProps {
 
 export const BundleDescriptionTabComponent: FC<BundleDescriptionTabComponentProps> = ({ bundle }) => {
     return (
-        <Paper variant={"outlined"} sx={{ justifySelf: "center", p: 2, m: 2, width: { xs: "100%", md: "50%" } }}>
+        <Paper variant={"outlined"} sx={{ p: 2, m: 2, mx: "auto", width: { xs: "100%", md: "50%" }}}>
             <Stack spacing={3} useFlexGap>
-                <Typography color={"primary"} variant={"h4"}>{bundle.name}</Typography>
+                <Typography color={"primary"} variant={"h4"} align="center">
+                    {bundle.name}
+                </Typography>
                 <Box>
                     <Stack direction={"row"} alignItems={"end"} justifyContent={"space-between"}>
                         <Typography textAlign={"start"}>

--- a/edukate-frontend/src/components/bundle/BundleSettingsTabComponent.tsx
+++ b/edukate-frontend/src/components/bundle/BundleSettingsTabComponent.tsx
@@ -10,7 +10,7 @@ interface BundleUserManagementComponentProps {
 const BundleUserManagementComponent: FC<BundleUserManagementComponentProps> = ({ bundle }) => {
     return (
         <Box>
-            <Typography color={"primary"} variant={"h4"}>
+            <Typography color={"primary"} variant={"h4"} align="center">
                 Users
             </Typography>
             <UserRolesManagementComponent shareCode={ bundle.shareCode }/>
@@ -25,7 +25,7 @@ interface BundleSettingsTabComponentProps {
 export const BundleSettingsTabComponent: FC<BundleSettingsTabComponentProps> = ({ bundle }) => {
     return (
         <Box>
-            <Paper variant={"outlined"} sx={{ justifySelf: "center", p: 2, m: 2, width: { xs: "100%", md: "50%" } }}>
+            <Paper variant={"outlined"} sx={{ p: 2, m: 2, mx: "auto", width: { xs: "100%", md: "50%" }}}>
                 <BundleUserManagementComponent bundle={bundle}/>
             </Paper>
         </Box>


### PR DESCRIPTION
### What's done:
 * Added `align="center"` to `Typography` headers in `BundleDescriptionTabComponent` and `BundleSettingsTabComponent`.
 * Updated `Paper` components to use `mx: "auto"` for consistent horizontal centering.