### PR TITLE
Refactor User Management Components

### DIFF
--- a/edukate-frontend/src/components/bundle/BundleSettingsTabComponent.tsx
+++ b/edukate-frontend/src/components/bundle/BundleSettingsTabComponent.tsx
@@ -1,7 +1,7 @@
 import { FC } from "react";
-import {Box, Paper, Typography} from "@mui/material";
+import { Box, Paper, Typography } from "@mui/material";
 import { Bundle } from "../../types/bundle/Bundle";
-import { UserRolesManagementComponent } from "../user/UserRolesManagementComponent";
+import { BundleUserManagement } from "../user/BundleUserManagement";
 
 interface BundleUserManagementComponentProps {
     bundle: Bundle;
@@ -13,7 +13,7 @@ const BundleUserManagementComponent: FC<BundleUserManagementComponentProps> = ({
             <Typography color={"primary"} variant={"h4"} align="center">
                 Users
             </Typography>
-            <UserRolesManagementComponent shareCode={ bundle.shareCode }/>
+            <BundleUserManagement shareCode={ bundle.shareCode }/>
         </Box>
     )
 };

--- a/edukate-frontend/src/components/user/InvitedUsersManagementComponent.tsx
+++ b/edukate-frontend/src/components/user/InvitedUsersManagementComponent.tsx
@@ -1,0 +1,59 @@
+import { FC } from "react";
+import { Avatar, Divider, IconButton, List, ListItem, ListItemAvatar, ListItemText, Paper } from "@mui/material";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
+import { getColorByStringHash, getFirstLetters } from "../../utils/utils";
+import { useBundleExpireInviteMutation, useBundleInvitedUserListQuery } from "../../http/requests";
+import { toast } from "react-toastify";
+import { UserSearchInputForm } from "./UserSearchInputForm";
+
+interface InvitedUsersManagementComponentProps {
+    shareCode: string;
+}
+
+export const InvitedUsersManagementComponent: FC<InvitedUsersManagementComponentProps> = ({ shareCode }) => {
+    const expireInviteMutation = useBundleExpireInviteMutation();
+
+    const { data: invitedUsers, refetch: refetchInvitedUsers } = useBundleInvitedUserListQuery(shareCode);
+
+    const handleRemoveInvitation = (username: string) => {
+        expireInviteMutation.mutate({ shareCode, username }, {
+            onSuccess: () => {
+                toast.info(`Invitation to ${username} has been removed`);
+                refetchInvitedUsers().then();
+            },
+            onError: () => {
+                toast.error(`Failed to remove invitation to ${username}`);
+            }
+        });
+    };
+
+    return (
+        <Paper variant="outlined" sx={{ borderRadius: 0 }}>
+            <UserSearchInputForm bundleShareCode={shareCode} onInvited={() => refetchInvitedUsers()} />
+            <Divider/>
+            <List sx={{ width: '100%', bgcolor: 'background.paper' }}>
+                {invitedUsers?.length === 0 && (
+                    <ListItem>
+                        <ListItemText secondary="No pending invitations" />
+                    </ListItem>
+                )}
+                {invitedUsers && invitedUsers.map((username) => (
+                    <ListItem key={`invited-${username}`} secondaryAction={
+                        <IconButton
+                            edge="end" aria-label="remove-invitation" onClick={() => handleRemoveInvitation(username)}
+                        >
+                            <DeleteOutlineIcon />
+                        </IconButton>
+                    }>
+                        <ListItemAvatar>
+                            <Avatar sx={{ backgroundColor: getColorByStringHash(username) }}>
+                                {getFirstLetters(username, 2)}
+                            </Avatar>
+                        </ListItemAvatar>
+                        <ListItemText primary={username} secondary="Invitation pending" />
+                    </ListItem>
+                ))}
+            </List>
+        </Paper>
+    );
+}

--- a/edukate-frontend/src/components/user/UserSearchInputForm.tsx
+++ b/edukate-frontend/src/components/user/UserSearchInputForm.tsx
@@ -1,0 +1,56 @@
+import { FC, KeyboardEventHandler, useState } from "react";
+import { useBundleInviteUserMutation } from "../../http/requests";
+import { toast } from "react-toastify";
+import { IconButton, InputBase, Paper } from "@mui/material";
+import AddIcon from "@mui/icons-material/AddOutlined";
+
+interface UserSearchInputFormProps {
+    bundleShareCode: string;
+    onInvited?: (username: string) => void;
+}
+
+export const UserSearchInputForm: FC<UserSearchInputFormProps> = ({ bundleShareCode, onInvited }) => {
+    const [username, setUsername] = useState("");
+    const inviteUserMutation = useBundleInviteUserMutation();
+
+    const canInvite = username.trim().length > 0 && !inviteUserMutation.isPending;
+
+    const onAddClick = () => {
+        if (!canInvite) return;
+        const normalized = username.trim();
+        inviteUserMutation.mutate({ username: normalized, shareCode: bundleShareCode }, {
+            onSuccess: () => {
+                toast.success(`User ${normalized} has been invited!`);
+                setUsername("");
+                onInvited?.(normalized);
+            },
+            onError: () => {
+                toast.error(`Could not invite ${normalized}!`);
+            },
+        });
+    };
+
+    const onKeyDown: KeyboardEventHandler<HTMLInputElement> = (e) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            onAddClick();
+        }
+    }
+
+    return (
+        <Paper
+            component="form" variant={"outlined"}
+            sx={{ p: '0px 1px', display: 'flex', alignItems: 'center', border: 0 }}
+            onSubmit={(e) => { e.preventDefault(); onAddClick(); }}
+        >
+            <InputBase
+                sx={{ ml: 1, flex: 1 }} placeholder="Username" value={username}
+                onChange={(e) => setUsername(e.target.value)} onKeyDown={onKeyDown}
+                inputProps={{ 'aria-label': 'username' }}
+            />
+            <IconButton color="primary" aria-label="add user" onClick={onAddClick} disabled={!canInvite}>
+                <AddIcon/>
+            </IconButton>
+        </Paper>
+    );
+};

--- a/edukate-frontend/src/http/requests.ts
+++ b/edukate-frontend/src/http/requests.ts
@@ -10,7 +10,7 @@ import { ProblemMetadata } from "../types/problem/ProblemMetadata";
 import { Result } from "../types/problem/Result";
 import { CreateSubmissionRequest } from "../types/submission/CreateSubmissionRequest";
 import { Submission } from "../types/submission/Submission";
-import { UserWithRole } from "../types/user/UserWithRole";
+import { UserNameWithRole } from "../types/user/UserNameWithRole";
 import { defaultErrorHandler } from "./utils";
 import { NotificationStatistics } from "../types/notification/NotificationStatistics";
 
@@ -316,7 +316,25 @@ export function useBundleUserListQuery(shareCode: string) {
                 return null;
             }
             try {
-                const response = await client.get<UserWithRole[]>(`/api/v1/bundles/${shareCode}/users`);
+                const response = await client.get<UserNameWithRole[]>(`/api/v1/bundles/${shareCode}/users`);
+                return response.data;
+            } catch (error) {
+                throw defaultErrorHandler(error);
+            }
+        }
+    })
+}
+
+export function useBundleInvitedUserListQuery(shareCode: string) {
+    const { isAuthorized } = useAuthContext();
+    return useQuery({
+        queryKey: ['bundle', 'invited-user', 'list', shareCode, isAuthorized],
+        queryFn: async () => {
+            if (!isAuthorized) {
+                return null;
+            }
+            try {
+                const response = await client.get<string[]>(`/api/v1/bundles/${shareCode}/invited-users`);
                 return response.data;
             } catch (error) {
                 throw defaultErrorHandler(error);
@@ -358,5 +376,25 @@ export function useRandomProblemIdQuery() {
             }
         },
         enabled: false
+    })
+}
+
+export function useBundleExpireInviteMutation() {
+    const { isAuthorized } = useAuthContext();
+    return useMutation({
+        mutationKey: ['bundle', 'user', 'expire-invite'],
+        mutationFn: async ({ shareCode, username }: { shareCode: string, username: string }) => {
+            if (!isAuthorized) {
+                return null;
+            }
+            try {
+                const response = await client.post<string>(`/api/v1/bundles/${shareCode}/expire-invite`, undefined, {
+                    params: { shareCode, inviteeName: username }
+                });
+                return response.status;
+            } catch (error) {
+                throw defaultErrorHandler(error);
+            }
+        }
     })
 }

--- a/edukate-frontend/src/types/user/UserNameWithRole.ts
+++ b/edukate-frontend/src/types/user/UserNameWithRole.ts
@@ -1,0 +1,6 @@
+import { Role } from "./Role";
+
+export type UserNameWithRole = {
+    name: string;
+    role: Role;
+};

--- a/edukate-frontend/src/types/user/UserWithRole.ts
+++ b/edukate-frontend/src/types/user/UserWithRole.ts
@@ -1,6 +1,0 @@
-import { Role } from "./Role";
-
-export type UserWithRole = {
-    username: string;
-    role: Role;
-};


### PR DESCRIPTION
Closes #20

### What's done:
 * Renamed `UserRolesManagementComponent` to `BundleUserManagement`.
 * Moved user invitation logic to new `InvitedUsersManagementComponent` and `UserSearchInputForm`.
 * Updated types: renamed `UserWithRole` to `UserNameWithRole` and adjusted related APIs.
 * Added API calls for managing invitations: `useBundleInvitedUserListQuery` and `useBundleExpireInviteMutation`.
 * Updated `BundleSettingsTabComponent` to use `BundleUserManagement` for improved component structure.