### PR TITLE
Backend should gather submission context and save check result

### DIFF
--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/internal/CheckerInternalController.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/controllers/internal/CheckerInternalController.java
@@ -1,0 +1,33 @@
+package io.github.sanyavertolet.edukate.backend.controllers.internal;
+
+import io.github.sanyavertolet.edukate.backend.services.CheckResultService;
+import io.github.sanyavertolet.edukate.backend.services.SubmissionService;
+import io.github.sanyavertolet.edukate.common.checks.CheckResult;
+import io.github.sanyavertolet.edukate.common.checks.SubmissionContext;
+import io.swagger.v3.oas.annotations.Hidden;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+import reactor.core.publisher.Mono;
+
+@Hidden
+@RequiredArgsConstructor
+@RequestMapping("/internal/checker")
+@RestController
+public class CheckerInternalController {
+    private final SubmissionService submissionService;
+    private final CheckResultService checkResultService;
+
+    @PostMapping("/report")
+    public Mono<Void> reportCheckerResult(@RequestBody CheckResult checkResult) {
+        return checkResultService.save(checkResult).then();
+    }
+
+    @GetMapping("/context")
+    public Mono<SubmissionContext> getSubmissionContextById(@RequestParam(name = "id") String submissionId) {
+        return submissionService.findSubmissionById(submissionId)
+                .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND, "Submission not found")))
+                .flatMap(submissionService::prepareContext);
+    }
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Problem.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/entities/Problem.java
@@ -11,7 +11,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceCreator;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -40,18 +39,6 @@ public class Problem {
 
     public enum Status {
         SOLVED, SOLVING, FAILED, NOT_SOLVED
-    }
-
-    public void addImageIfNotPresent(String imageName) {
-        if (images == null) {
-            images = new ArrayList<>();
-            images.add(imageName);
-            return;
-        }
-        boolean contains = images.contains(imageName);
-        if (!contains) {
-            images.add(imageName);
-        }
     }
 
     public ProblemMetadata toProblemMetadata() {

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/CheckResultRepository.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/repositories/CheckResultRepository.java
@@ -1,0 +1,10 @@
+package io.github.sanyavertolet.edukate.backend.repositories;
+
+import io.github.sanyavertolet.edukate.common.checks.CheckResult;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CheckResultRepository extends ReactiveMongoRepository<CheckResult, String> {
+
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/CheckResultService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/CheckResultService.java
@@ -1,0 +1,17 @@
+package io.github.sanyavertolet.edukate.backend.services;
+
+import io.github.sanyavertolet.edukate.backend.repositories.CheckResultRepository;
+import io.github.sanyavertolet.edukate.common.checks.CheckResult;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+@AllArgsConstructor
+public class CheckResultService {
+    private final CheckResultRepository checkResultRepository;
+
+    public Mono<CheckResult> save(CheckResult checkResult) {
+        return checkResultRepository.save(checkResult);
+    }
+}

--- a/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/BaseFileService.java
+++ b/edukate-backend/src/main/java/io/github/sanyavertolet/edukate/backend/services/files/BaseFileService.java
@@ -26,6 +26,12 @@ public class BaseFileService {
         return storage.download(key);
     }
 
+    public Flux<String> getDownloadUrlsByFileObjectIds(Iterable<String> fileObjectIds) {
+        return fileObjectRepository.findAllById(fileObjectIds)
+                .map(FileObject::getKey)
+                .flatMap(storage::getDownloadUrl);
+    }
+
     public Mono<String> getDownloadUrlOrEmpty(FileKey key) {
         return Mono.justOrEmpty(key).filterWhen(storage::doesExist).flatMap(storage::getDownloadUrl);
     }

--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/CheckErrorType.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/CheckErrorType.java
@@ -1,0 +1,10 @@
+package io.github.sanyavertolet.edukate.common.checks;
+
+public enum CheckErrorType {
+    CONCEPTUAL,
+    ALGEBRAIC,
+    NUMERICAL,
+    UNIT,
+    INCOMPLETE,
+    UNCLEAR,
+}

--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/CheckResult.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/CheckResult.java
@@ -1,0 +1,16 @@
+package io.github.sanyavertolet.edukate.common.checks;
+
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Data
+@Builder
+@Document(collection = "check_results")
+public class CheckResult {
+    private String submissionId;
+    private CheckStatus status;
+    private Float trustLevel;
+    private CheckErrorType errorType;
+    private String explanation;
+}

--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/CheckStatus.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/CheckStatus.java
@@ -1,0 +1,6 @@
+package io.github.sanyavertolet.edukate.common.checks;
+
+public enum CheckStatus {
+    SUCCESS,
+    MISTAKE,
+}

--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/ModelResponse.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/ModelResponse.java
@@ -1,0 +1,15 @@
+package io.github.sanyavertolet.edukate.common.checks;
+
+import lombok.Data;
+
+@Data
+public class ModelResponse {
+    private CheckStatus status;
+    private Float trustLevel;
+    private CheckErrorType errorType;
+    private String explanation;
+
+    public CheckResult toCheckResult(String submissionId) {
+        return new CheckResult(submissionId, status, trustLevel, errorType, explanation);
+    }
+}

--- a/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/SubmissionContext.java
+++ b/edukate-common/src/main/java/io/github/sanyavertolet/edukate/common/checks/SubmissionContext.java
@@ -1,0 +1,16 @@
+package io.github.sanyavertolet.edukate.common.checks;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class SubmissionContext {
+    private String submissionId;
+    private String problemId;
+    private String problemText;
+    private List<String> problemImageUrls;
+    private List<String> submissionImageUrls;
+}


### PR DESCRIPTION
### What's done:
 * Introduced `CheckResultService` and `CheckResultRepository` for handling check result persistence.
 * Added `CheckResult` model class with fields for status, trust level, error type, and explanation.
 * Implemented `SubmissionContext` class to encapsulate context data for submissions and problems.
 * Extended `ProblemService` with `problemImageDownloadUrls` helper method.
 * Updated `SubmissionService` to prepare `SubmissionContext` with problem and submission details.
 * Created `CheckerInternalController` for internal API to manage check results and retrieve submission contexts.
 * Enhanced `BaseFileService` to fetch file download URLs using object IDs.