### PR TITLE
Add `checker` microservice deployment to Helm chart

### DIFF
--- a/edukate-chart/templates/checker.yaml
+++ b/edukate-chart/templates/checker.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.checker.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{ include "common.labels" (merge (dict "service" .Values.checker) .) | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      io.kompose.service: checker
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        {{ include "pod.common.labels" (merge (dict "service" .Values.checker ) .) | nindent 8 }}
+      annotations:
+        {{ include "pod.common.annotations" (dict "service" .Values.checker ) | nindent 8 }}
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: notifier
+          {{ include "spring-boot.common" (merge (dict "service" .Values.checker) .) | nindent 10 }}
+          env:
+            {{ include "spring-boot.common.env" (merge (dict "service" .Values.checker) .) | nindent 12 }}
+            - name: OPENAI_SYSTEM_PROMPT
+              valueFrom:
+                secretKeyRef:
+                  name: openai-secret
+                  key: prompt
+            - name: OPENAI_MODEL
+              valueFrom:
+                secretKeyRef:
+                  name: openai-secret
+                  key: model
+            - name: OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: openai-secret
+                  key: key
+          {{ include "spring-boot.management" .Values.checker | nindent 10 }}
+
+---
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.checker.name }}-config
+  namespace: {{ .Values.namespace }}
+data:
+  application.properties: |
+    {{ if .Values.checker.applicationProperties }}
+    {{ .Values.checker.applicationProperties | nindent 4 }}
+    {{ end }}
+
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+{{ include "service.common.metadata" (dict "service" .Values.checker) | nindent 2 }}
+  namespace: {{ .Values.namespace }}
+spec:
+  ports:
+    {{ include "service.common.ports" (dict "service" .Values.checker) | nindent 4 }}
+  selector:
+    {{ include "service.common.selectors" (dict "service" .Values.checker) | nindent 4 }}

--- a/edukate-chart/values.yaml
+++ b/edukate-chart/values.yaml
@@ -45,6 +45,15 @@ notifier:
   clusterIP: null
   applicationProperties:
 
+checker:
+  name: checker
+  imageName: edukate-checker
+  pullPolicy: Always
+  containerPort: 5830
+  managementPort: 5831
+  clusterIP: null
+  applicationProperties:
+
 ingress:
   tls:
     profile: "staging"


### PR DESCRIPTION
### What's done:
 * Added `checker` Deployment definition in `checker.yaml` with environment variable configurations for OpenAI integration.
 * Introduced a `checker` ConfigMap for application properties.
 * Added `checker` Service configuration in the Helm chart.
 * Updated `values.yaml` to include `checker` service configurations such as `imageName`, `ports`, and `applicationProperties`.