### PR TITLE
Add RabbitMQ configuration for helm chart

### DIFF
--- a/edukate-chart/templates/_helpers.tpl
+++ b/edukate-chart/templates/_helpers.tpl
@@ -79,4 +79,12 @@ configMap:
   items:
     - key: application.properties
       path: application.properties
-{{- end}}
+{{- end }}
+
+{{- define "rabbitmq.addresses.env" -}}
+- name: RABBITMQ_ADDRESSES
+  valueFrom:
+    secretKeyRef:
+      name: edukate-rabbit-default-user
+      key: connection_string
+{{- end }}

--- a/edukate-chart/templates/backend.yaml
+++ b/edukate-chart/templates/backend.yaml
@@ -58,6 +58,7 @@ spec:
                   name: {{ .Values.s3.secretName }}
                   key: "endpoint"
             {{ end }}
+            {{ include "rabbitmq.addresses.env" . | nindent 12 | trim }}
           volumeMounts:
             - {{ include "spring-boot.config-volume-mount" . | indent 14 | trim }}
           {{- include "spring-boot.management" .Values.backend | nindent 10 }}

--- a/edukate-chart/templates/checker.yaml
+++ b/edukate-chart/templates/checker.yaml
@@ -39,6 +39,7 @@ spec:
                 secretKeyRef:
                   name: openai-secret
                   key: key
+            {{ include "rabbitmq.addresses.env" . | nindent 12 | trim }}
           {{ include "spring-boot.management" .Values.checker | nindent 10 }}
 
 ---

--- a/edukate-chart/templates/notifier.yaml
+++ b/edukate-chart/templates/notifier.yaml
@@ -31,6 +31,7 @@ spec:
                   name: {{ .Values.mongodb.secretName }}
                   key: {{ .Values.mongodb.secretKey.notifier }}
             {{ end }}
+            {{ include "rabbitmq.addresses.env" . | nindent 12 | trim }}
           volumeMounts:
             - {{ include "spring-boot.config-volume-mount" . | indent 14 | trim }}
           {{ include "spring-boot.management" .Values.notifier | nindent 10 }}

--- a/edukate-chart/templates/rabbitmq.yaml
+++ b/edukate-chart/templates/rabbitmq.yaml
@@ -1,0 +1,10 @@
+apiVersion: rabbitmq.com/v1beta1
+kind: RabbitmqCluster
+metadata:
+  name: edukate-rabbit
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  image: rabbitmq:4.0-management
+  persistence:
+    storage: 10Gi


### PR DESCRIPTION
### What's done:
 * Added `RabbitmqCluster` resource definition in `rabbitmq.yaml` to enable RabbitMQ deployment.
 * Introduced `rabbitmq.addresses.env` helper template in `_helpers.tpl` for dynamic RabbitMQ connection string injection.
 * Updated `checker.yaml`, `notifier.yaml`, and `backend.yaml` to reference RabbitMQ connection string using the new helper.