### PR TITLE
Fix frontend build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,8 +19,7 @@ edukate-frontend/dist/
 edukate-frontend/coverage/
 edukate-frontend/src/generated/
 
-# Git and IDE
-.git/
+# IDE and Claude
 .github/
 .idea/
 .claude/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Backend — not needed for the frontend image
+edukate-auth/
+edukate-backend/
+edukate-checker/
+edukate-common/
+edukate-gateway/
+edukate-messaging/
+edukate-notifier/
+edukate-storage/
+gradle/
+gradlew
+gradlew.bat
+*.gradle
+*.gradle.kts
+
+# Frontend build artifacts and dev-only files
+edukate-frontend/node_modules/
+edukate-frontend/dist/
+edukate-frontend/coverage/
+edukate-frontend/src/generated/
+
+# Git and IDE
+.git/
+.github/
+.idea/
+.claude/
+
+# Misc
+*.md
+edukate-problems/
+edukate-data/

--- a/gradle/plugins/src/main/kotlin/io/github/sanyavertolet/edukate/buildutils/BuildImageUtils.kt
+++ b/gradle/plugins/src/main/kotlin/io/github/sanyavertolet/edukate/buildutils/BuildImageUtils.kt
@@ -85,6 +85,7 @@ fun DockerBuildImage.configureFrontendBuild(
     description = "Builds the frontend Docker image"
 
     inputDir.set(project.layout.projectDirectory)
+    dockerFile.set(project.layout.projectDirectory.file("$frontendName/Dockerfile"))
     if (shouldPublishLatest) {
         images.add(fullImageNameWithTag(frontendName, "latest"))
     }

--- a/gradle/plugins/src/main/kotlin/io/github/sanyavertolet/edukate/buildutils/BuildImageUtils.kt
+++ b/gradle/plugins/src/main/kotlin/io/github/sanyavertolet/edukate/buildutils/BuildImageUtils.kt
@@ -84,7 +84,7 @@ fun DockerBuildImage.configureFrontendBuild(
     group = "docker"
     description = "Builds the frontend Docker image"
 
-    inputDir.set(project.layout.projectDirectory.dir(frontendName))
+    inputDir.set(project.layout.projectDirectory)
     if (shouldPublishLatest) {
         images.add(fullImageNameWithTag(frontendName, "latest"))
     }


### PR DESCRIPTION
### What's done:
 * Created a `.dockerignore` file to exclude unnecessary files and directories from Docker context.
 * Updated `BuildImageUtils.kt` to use the project root as the `inputDir` for frontend Docker image builds.