### PR TITLE
Update production URLs and resource configurations

### DIFF
--- a/edukate-backend/src/main/resources/application.properties
+++ b/edukate-backend/src/main/resources/application.properties
@@ -24,4 +24,4 @@ s3.signature-duration=1h
 
 spring.rabbitmq.addresses=${RABBITMQ_ADDRESSES}
 
-gateway.url=https://edukate.mooo.com
+gateway.url=https://edukatemeplease.online

--- a/edukate-chart/values-prod.yaml
+++ b/edukate-chart/values-prod.yaml
@@ -7,8 +7,8 @@ profile: prod,secure
 checker:
   resources:
     requests:
-      memory: "512Mi"
-      cpu: "200m"
+      memory: "256Mi"
+      cpu: "100m"
     limits:
       memory: "1Gi"
       cpu: "1000m"
@@ -31,7 +31,7 @@ ingress:
 #   either staging or prod
     profile: "prod"
     email: "lxnfrolov@gmail.com"
-  host: "edukate.mooo.com"
+  host: "edukatemeplease.online"
 
 s3:
   enabled: true
@@ -62,8 +62,8 @@ kube-prometheus-stack:
     adminPassword: ""
     resources:
       requests:
-        cpu: 100m
-        memory: 256Mi
+        cpu: 50m
+        memory: 128Mi
       limits:
         cpu: 500m
         memory: 512Mi
@@ -72,8 +72,8 @@ kube-prometheus-stack:
       retention: 30d
       resources:
         requests:
-          cpu: 200m
-          memory: 512Mi
+          cpu: 100m
+          memory: 256Mi
         limits:
           cpu: 1000m
           memory: 1Gi
@@ -85,8 +85,8 @@ loki:
     replicas: 1
     resources:
       requests:
-        cpu: 100m
-        memory: 256Mi
+        cpu: 50m
+        memory: 128Mi
       limits:
         cpu: 500m
         memory: 512Mi
@@ -95,8 +95,8 @@ tempo:
   tempo:
     resources:
       requests:
-        cpu: 100m
-        memory: 256Mi
+        cpu: 50m
+        memory: 128Mi
       limits:
         cpu: 500m
         memory: 512Mi

--- a/edukate-chart/values.yaml
+++ b/edukate-chart/values.yaml
@@ -102,6 +102,20 @@ kube-prometheus-stack:
     fullnameOverride: grafana
     # Override via --set or grafana.admin.existingSecret in production
     adminPassword: "changeme"
+    persistence:
+      enabled: true
+      size: 1Gi
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        cert-manager.io/cluster-issuer: edukate-letsencrypt-issuer-prod
+      hosts:
+        - grafana.edukatemeplease.online
+      tls:
+        - secretName: grafana-tls
+          hosts:
+            - grafana.edukatemeplease.online
     additionalDataSources:
       # Loki datasource — correlated to Tempo traces via traceId field in JSON logs
       - name: Loki
@@ -118,7 +132,7 @@ kube-prometheus-stack:
       # Tempo datasource — links traces back to Loki logs
       - name: Tempo
         type: tempo
-        url: http://tempo:3100
+        url: http://tempo:3200
         access: proxy
         uid: tempo
         jsonData:
@@ -151,10 +165,15 @@ kube-prometheus-stack:
               regex: ([^:]+)(?::\d+)?;(\d+)
               replacement: $1:$2
               target_label: __address__
-            # Carry the kompose service label as a Prometheus "service" label
+            # Carry the kompose service label as both "service" and "application" labels.
+            # "service" is used internally; "application" makes community dashboards
+            # (JVM Micrometer, Spring Boot Statistics, etc.) work without variable edits.
             - source_labels: [__meta_kubernetes_pod_label_io_kompose_service]
               action: replace
               target_label: service
+            - source_labels: [__meta_kubernetes_pod_label_io_kompose_service]
+              action: replace
+              target_label: application
   alertmanager:
     enabled: false  # enable once alert routing (PagerDuty/Slack/email) is configured
 
@@ -196,6 +215,15 @@ loki:
   # Disable bundled MinIO — using filesystem storage instead
   minio:
     enabled: false
+  # Disable memcached caches — not needed for single-binary filesystem storage
+  chunksCache:
+    enabled: false
+  resultsCache:
+    enabled: false
+  # Override Loki chart's default ingress.tls: [] (list) with an empty table to suppress
+  # "destination for loki.ingress.tls is a table. Ignoring non-table value ([])" warning
+  ingress:
+    tls: {}
 
 # ── Tempo — distributed tracing backend ─────────────────────────────────────
 # Receives OTLP traces from Spring Boot services; serves traces to Grafana

--- a/edukate-checker/src/main/resources/application.properties
+++ b/edukate-checker/src/main/resources/application.properties
@@ -26,4 +26,4 @@ s3.bucket=${S3_BUCKET}
 s3.endpoint=${S3_ENDPOINT}
 s3.signature-duration=1h
 
-gateway.url=https://edukate.mooo.com
+gateway.url=https://edukatemeplease.online

--- a/edukate-gateway/CLAUDE.md
+++ b/edukate-gateway/CLAUDE.md
@@ -34,7 +34,7 @@ routes traffic to downstream services.
 
 - `application.yml` / `application-dev.yml`
 - Port: 5810 (main), 5811 (management)
-- Prod CORS: `https://edukate.mooo.com`; Dev CORS: `http://localhost:[*]`
+- Prod CORS: `https://edukatemeplease.online`; Dev CORS: `http://localhost:[*]`
 - Profiles: `dev`, `secure`
 - JWT secret from `${JWT_SECRET}` env var (prod) or hardcoded (dev)
 

--- a/edukate-gateway/ROUTING.md
+++ b/edukate-gateway/ROUTING.md
@@ -141,24 +141,24 @@ The Swagger UI configuration is served at `/swagger/gateway/api-docs/swagger-con
 
 Configured in `WebSecurityConfig.corsConfigurationSource()`.
 
-| Setting                | Value                                                            |
-|------------------------|------------------------------------------------------------------|
-| Allowed origin pattern | `https://edukate.mooo.com` (prod) / `http://localhost:[*]` (dev) |
-| Allowed methods        | `GET, POST, PUT, DELETE, OPTIONS`                                |
-| Allowed headers        | `Content-Type, api_key`                                          |
-| Max age                | 3600 seconds                                                     |
-| Applied to             | `/**` (all paths)                                                |
+| Setting                | Value                                                                  |
+|------------------------|------------------------------------------------------------------------|
+| Allowed origin pattern | `https://edukatemeplease.online` (prod) / `http://localhost:[*]` (dev) |
+| Allowed methods        | `GET, POST, PUT, DELETE, OPTIONS`                                      |
+| Allowed headers        | `Content-Type, api_key`                                                |
+| Max age                | 3600 seconds                                                           |
+| Applied to             | `/**` (all paths)                                                      |
 
 ---
 
 ## Environment URLs
 
-| Property                      | Production                 | Development (`dev` profile) |
-|-------------------------------|----------------------------|-----------------------------|
-| `gateway.backend.url`         | `http://backend`           | `http://localhost:5800`     |
-| `gateway.notifier.url`        | `http://notifier`          | `http://localhost:5820`     |
-| `gateway.url`                 | `https://edukate.mooo.com` | `http://localhost:5810`     |
-| `cors.allowed-origin-pattern` | `https://edukate.mooo.com` | `http://localhost:[*]`      |
+| Property                      | Production                       | Development (`dev` profile) |
+|-------------------------------|----------------------------------|-----------------------------|
+| `gateway.backend.url`         | `http://backend`                 | `http://localhost:5800`     |
+| `gateway.notifier.url`        | `http://notifier`                | `http://localhost:5820`     |
+| `gateway.url`                 | `https://edukatemeplease.online` | `http://localhost:5810`     |
+| `cors.allowed-origin-pattern` | `https://edukatemeplease.online` | `http://localhost:[*]`      |
 
 ---
 

--- a/edukate-gateway/src/main/resources/application.yml
+++ b/edukate-gateway/src/main/resources/application.yml
@@ -3,7 +3,7 @@ gateway:
     url: http://backend
   notifier:
     url: http://notifier
-  url: https://edukate.mooo.com
+  url: https://edukatemeplease.online
 
 auth:
   jwt:
@@ -64,7 +64,7 @@ spring:
                 - RemoveRequestHeader=Cookie
 
 cors:
-  allowed-origin-pattern: https://edukate.mooo.com
+  allowed-origin-pattern: https://edukatemeplease.online
 
 server:
   port: 5810

--- a/edukate-notifier/src/main/resources/application.properties
+++ b/edukate-notifier/src/main/resources/application.properties
@@ -16,4 +16,4 @@ springdoc.swagger-ui.enabled=false
 
 spring.rabbitmq.addresses=${RABBITMQ_ADDRESSES}
 
-gateway.url=https://edukate.mooo.com
+gateway.url=https://edukatemeplease.online

--- a/spec/openapi-edukate-gateway.yaml
+++ b/spec/openapi-edukate-gateway.yaml
@@ -3,7 +3,7 @@ info:
   title: OpenAPI definition
   version: v0
 servers:
-- url: https://edukate.mooo.com
+- url: https://edukatemeplease.online
 security:
 - cookieAuth: []
 tags:


### PR DESCRIPTION
### What's done:
 * Replaced all instances of `https://edukate.mooo.com` with `https://edukatemeplease.online` across configs and documentation.
 * Enabled persistence, ingress, and TLS for Grafana in Helm values.
 * Adjusted resource requests and limits for multiple services in `values-prod.yaml` to reduce memory and CPU usage.
 * Fixed incorrect Tempo URL in Grafana data sources.
 * Enhanced Prometheus relabeling to support "application" labels for better dashboard compatibility.
 * Disabled Loki caches and suppressed ingress TLS warnings.