### PR TITLE
Add enhancements for metrics, labels, and testing

### DIFF
--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/files/FileManager.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/files/FileManager.kt
@@ -136,10 +136,19 @@ class FileManager(private val fileObjectRepository: FileObjectRepository, privat
                 }
             }
             .switchIfEmpty(
-                fileObjectRepository.save(FileObject.fromStorageState(newPath, newKey, type, owner, metadata)).doOnSuccess {
-                    created ->
-                    log.debug("Created file object: key={}", created?.key)
-                }
+                fileObjectRepository
+                    .findByKeyPath(newPath)
+                    .flatMap { existing ->
+                        val updated = existing.withStorageState(newPath, newKey, type, owner, metadata)
+                        fileObjectRepository.save(updated).doOnSuccess { saved ->
+                            log.debug("Re-used existing file object: key={}", saved?.key)
+                        }
+                    }
+                    .switchIfEmpty(
+                        fileObjectRepository
+                            .save(FileObject.fromStorageState(newPath, newKey, type, owner, metadata))
+                            .doOnSuccess { created -> log.debug("Created file object: key={}", created?.key) }
+                    )
             )
             .timeout(DEFAULT_TIMEOUT)
             .doOnError { e -> log.error("saveOrUpdateByKeyPath failed: lookup={} newKey={}", lookupKeyPath, newKey, e) }

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/FileManagerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/FileManagerTest.kt
@@ -224,9 +224,39 @@ class FileManagerTest {
         every { storage.move(oldKey, newKey) } returns Mono.just(true)
         every { storage.metadata(newKey) } returns Mono.just(metadata)
         every { fileObjectRepository.findByKeyPath(oldKey.toString()) } returns Mono.empty()
+        every { fileObjectRepository.findByKeyPath(newKey.toString()) } returns Mono.empty()
         every { fileObjectRepository.save(any()) } answers { Mono.just(firstArg()) }
 
         StepVerifier.create(fileManager.moveFile(oldKey, newKey)).expectNext(newKey).verifyComplete()
+    }
+
+    @Test
+    fun `moveFile reuses existing file object when old path missing but new path already exists`() {
+        val oldKey = TempFileKey("user-1", "draft.txt")
+        val newKey = SubmissionFileKey("user-1", "1.0.0", "sub-1", "draft.txt")
+        val metadata = meta()
+        val existingFo =
+            FileObject(
+                id = "fo-existing",
+                keyPath = newKey.toString(),
+                key = newKey,
+                type = "submission",
+                ownerUserId = "user-1",
+                metadata = meta(50L),
+            )
+
+        every { storage.move(oldKey, newKey) } returns Mono.just(true)
+        every { storage.metadata(newKey) } returns Mono.just(metadata)
+        // Old tmp path not in DB (already moved in a previous attempt)
+        every { fileObjectRepository.findByKeyPath(oldKey.toString()) } returns Mono.empty()
+        // New final path already has a record (from that previous attempt)
+        every { fileObjectRepository.findByKeyPath(newKey.toString()) } returns Mono.just(existingFo)
+        every { fileObjectRepository.save(any()) } answers { Mono.just(firstArg()) }
+
+        StepVerifier.create(fileManager.moveFile(oldKey, newKey)).expectNext(newKey).verifyComplete()
+
+        // Must update the existing record, not create a new one
+        verify(exactly = 1) { fileObjectRepository.save(match { it.id == "fo-existing" }) }
     }
 
     @Test

--- a/edukate-chart/CLAUDE.md
+++ b/edukate-chart/CLAUDE.md
@@ -78,8 +78,8 @@ These Kubernetes Secrets must exist in the target namespace before `helm install
 
 | Helper | Purpose |
 |--------|---------|
-| `common.labels` | Deployment-level labels: `io.kompose.service`, `version`, `env` |
-| `pod.common.labels` | Pod template labels: `io.kompose.service`, `version` |
+| `common.labels` | Deployment-level labels: `io.kompose.service`, `app.kubernetes.io/name`, `app.kubernetes.io/part-of: edukate`, `version`, `env` |
+| `pod.common.labels` | Pod template labels: `io.kompose.service`, `app.kubernetes.io/name`, `app.kubernetes.io/part-of: edukate`, `version` |
 | `pod.common.annotations` | Prometheus scrape annotations — sets `scrape: "true"`, `path: /actuator/prometheus`, `port: <managementPort>` |
 | `spring-boot.common` | Container `image`, `imagePullPolicy`, `ports`, `resources` |
 | `spring-boot.common.env` | `SPRING_PROFILES_ACTIVE` env var |

--- a/edukate-chart/templates/_helpers.tpl
+++ b/edukate-chart/templates/_helpers.tpl
@@ -1,11 +1,15 @@
 {{- define "common.labels" -}}
 io.kompose.service: {{ .service.name }}
+app.kubernetes.io/name: {{ .service.name }}
+app.kubernetes.io/part-of: edukate
 version: {{ or .service.dockerTag .Values.dockerTag }}
 env: {{ .Values.env }}
 {{- end }}
 
 {{- define "pod.common.labels" }}
 io.kompose.service: {{ .service.name }}
+app.kubernetes.io/name: {{ .service.name }}
+app.kubernetes.io/part-of: edukate
 version: {{ or .service.dockerTag .Values.dockerTag }}
 {{- end }}
 

--- a/edukate-chart/values-prod.yaml
+++ b/edukate-chart/values-prod.yaml
@@ -15,6 +15,7 @@ checker:
   applicationProperties: |
     management.opentelemetry.tracing.export.otlp.endpoint=http://tempo:4318/v1/traces
     management.tracing.sampling.probability=0.5
+    management.otlp.metrics.export.enabled=false
 
 autoscaling:
   enabled: false
@@ -106,14 +107,17 @@ backend:
   applicationProperties: |
     management.opentelemetry.tracing.export.otlp.endpoint=http://tempo:4318/v1/traces
     management.tracing.sampling.probability=0.5
+    management.otlp.metrics.export.enabled=false
 
 gateway:
   applicationProperties: |
     management.opentelemetry.tracing.export.otlp.endpoint=http://tempo:4318/v1/traces
     management.tracing.sampling.probability=0.5
+    management.otlp.metrics.export.enabled=false
 
 notifier:
   applicationProperties: |
     management.opentelemetry.tracing.export.otlp.endpoint=http://tempo:4318/v1/traces
     management.tracing.sampling.probability=0.5
+    management.otlp.metrics.export.enabled=false
 

--- a/edukate-chart/values.yaml
+++ b/edukate-chart/values.yaml
@@ -155,6 +155,8 @@ kube-prometheus-stack:
             datasourceUid: loki
             filterByTraceID: true
             filterBySpanID: false
+          serviceMap:
+            datasourceUid: prometheus
   prometheus:
     prometheusSpec:
       # Enable remote write receiver so Tempo metricsGenerator can push span-derived RED metrics
@@ -202,6 +204,14 @@ kube-prometheus-stack:
             - source_labels: [__meta_kubernetes_pod_label_io_kompose_service]
               action: replace
               target_label: service
+            # Expose Kubernetes namespace and pod name as metric labels.
+            # Required by the JVM Micrometer Grafana dashboard (ID 4701) alongside "application".
+            - source_labels: [__meta_kubernetes_namespace]
+              action: replace
+              target_label: namespace
+            - source_labels: [__meta_kubernetes_pod_name]
+              action: replace
+              target_label: pod
   alertmanager:
     enabled: false  # enable once alert routing (PagerDuty/Slack/email) is configured
 


### PR DESCRIPTION
### What's done:
 * Added support for Prometheus `serviceMap` in `values.yaml`.
 * Updated Prometheus scrape configuration to include `namespace` and `pod` labels for better metric visibility.
 * Enhanced common Kubernetes labels with `app.kubernetes.io/name` and `app.kubernetes.io/part-of: edukate`.
 * Improved `moveFile` functionality to reuse existing file objects when moving to new paths in `FileManager`.
 * Enabled handling of existing file records during `moveFile` operations.
 * Disabled OTLP metrics export in all service configurations for production stability.