### PR TITLE
Enable micrometer observation and configure application metric tags

### DIFF
--- a/edukate-backend/src/main/resources/application.properties
+++ b/edukate-backend/src/main/resources/application.properties
@@ -12,6 +12,7 @@ springdoc.swagger-ui.enabled=false
 management.server.port=5801
 management.endpoints.web.exposure.include=health,info,loggers,prometheus
 management.endpoint.prometheus.access=unrestricted
+management.metrics.tags.application=${spring.application.name}
 logging.group.edukate=io.github.sanyavertolet
 spring.web.error.include-message=always
 

--- a/edukate-chart/values.yaml
+++ b/edukate-chart/values.yaml
@@ -199,8 +199,8 @@ kube-prometheus-stack:
               replacement: $1:$2
               target_label: __address__
             # Carry the kompose service label as "service" for internal Prometheus use.
-            # The "application" label is emitted directly by Spring Boot 4 Micrometer
-            # autoconfiguration from spring.application.name — no relabeling needed.
+            # The "application" label is emitted by Micrometer via management.metrics.tags.application
+            # (set in each service's application.properties) — no relabeling needed.
             - source_labels: [__meta_kubernetes_pod_label_io_kompose_service]
               action: replace
               target_label: service

--- a/edukate-checker/src/main/kotlin/io/github/sanyavertolet/edukate/checker/configs/ObservationConfig.kt
+++ b/edukate-checker/src/main/kotlin/io/github/sanyavertolet/edukate/checker/configs/ObservationConfig.kt
@@ -1,0 +1,17 @@
+package io.github.sanyavertolet.edukate.checker.configs
+
+import io.micrometer.observation.ObservationRegistry
+import io.micrometer.observation.aop.ObservedAspect
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ObservationConfig {
+    /**
+     * Activates @Observed annotation processing via AOP.
+     *
+     * Spring Boot auto-configures ObservationRegistry but does NOT register ObservedAspect. Without this bean, all @Observed
+     * annotations are silently ignored — no spans, no metrics.
+     */
+    @Bean fun observedAspect(observationRegistry: ObservationRegistry): ObservedAspect = ObservedAspect(observationRegistry)
+}

--- a/edukate-checker/src/main/resources/application.properties
+++ b/edukate-checker/src/main/resources/application.properties
@@ -5,6 +5,7 @@ server.port=5830
 management.server.port=5831
 management.endpoints.web.exposure.include=health,info,loggers,prometheus
 management.endpoint.prometheus.access=unrestricted
+management.metrics.tags.application=${spring.application.name}
 logging.group.edukate=io.github.sanyavertolet
 spring.web.error.include-message=always
 

--- a/edukate-gateway/src/main/resources/application.yml
+++ b/edukate-gateway/src/main/resources/application.yml
@@ -81,6 +81,9 @@ management:
         enabled: true
     prometheus:
       access: unrestricted
+  metrics:
+    tags:
+      application: ${spring.application.name}
 
 logging:
   group:

--- a/edukate-notifier/src/main/resources/application.properties
+++ b/edukate-notifier/src/main/resources/application.properties
@@ -7,6 +7,7 @@ server.port=5820
 management.server.port=5821
 management.endpoints.web.exposure.include=health,info,loggers,prometheus
 management.endpoint.prometheus.access=unrestricted
+management.metrics.tags.application=${spring.application.name}
 logging.group.edukate=io.github.sanyavertolet
 spring.web.error.include-message=always
 


### PR DESCRIPTION
### What's done:
 * Added `ObservationConfig` to activate `@Observed` annotation processing via AOP.
 * Updated Prometheus relabeling comment in `values.yaml` for clarity.
 * Added `management.metrics.tags.application` property to `application.properties` and `application.yml` in all services to tag metrics with the application name.