### PR TITLE
Caching and suspend joining via bundle share code

### DIFF
--- a/.github/workflows/openapi.yml
+++ b/.github/workflows/openapi.yml
@@ -20,21 +20,14 @@ jobs:
       # The spec-gen Spring profile uses lazy/dummy connections — no external services required.
       # Services run in parallel: backend on 18080, gateway on 18081, notifier on 18082.
       - name: Regenerate OpenAPI specs
-        run: |
-          ./gradlew :edukate-backend:generateOpenApiDocs --no-daemon &
-          ./gradlew :edukate-gateway:generateOpenApiDocs --no-daemon &
-          ./gradlew :edukate-notifier:generateOpenApiDocs --no-daemon &
-          wait
+        run: ./gradlew :edukate-backend:generateOpenApiDocs :edukate-gateway:generateOpenApiDocs :edukate-notifier:generateOpenApiDocs --parallel --no-daemon
 
       - name: Check for spec drift
         run: |
           if ! git diff --exit-code spec/; then
             echo ""
             echo "OpenAPI specs are out of date. Regenerate and commit:"
-            echo "  ./gradlew :edukate-backend:generateOpenApiDocs &"
-            echo "  ./gradlew :edukate-gateway:generateOpenApiDocs &"
-            echo "  ./gradlew :edukate-notifier:generateOpenApiDocs &"
-            echo "  wait"
+            echo "  ./gradlew :edukate-backend:generateOpenApiDocs :edukate-gateway:generateOpenApiDocs :edukate-notifier:generateOpenApiDocs --parallel"
             exit 1
           fi
 

--- a/edukate-backend/CLAUDE.md
+++ b/edukate-backend/CLAUDE.md
@@ -8,14 +8,14 @@ Core business logic service. Manages problems, bundles, submissions, users, and 
 
 ## Domain Entities (MongoDB documents)
 
-| Entity              | Purpose                                                             |
-|---------------------|---------------------------------------------------------------------|
-| `Problem`           | Educational problem with subtasks, images, results, status          |
-| `Bundle`            | Collection of problems; has user roles (ADMIN, USER) and visibility |
-| `Submission`        | User's answer to a problem; statuses: PENDING, ACCEPTED, REJECTED   |
-| `User`              | Authentication data                                                 |
-| `CheckResult`       | AI checker output for a submission                                  |
-| `UserProblemStatus` | Junction — tracks per-user progress per problem                     |
+| Entity              | Purpose                                                                                                                                                           |
+|---------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Problem`           | Educational problem with subtasks, images, results, status                                                                                                        |
+| `Bundle`            | Collection of problems; has user roles (ADMIN, USER) and visibility. Membership is invite-only (no open join endpoint — see TODO.md for planned invite-link flow) |
+| `Submission`        | User's answer to a problem; statuses: PENDING, ACCEPTED, REJECTED                                                                                                 |
+| `User`              | Authentication data                                                                                                                                               |
+| `CheckResult`       | AI checker output for a submission                                                                                                                                |
+| `UserProblemStatus` | Junction — tracks per-user progress per problem                                                                                                                   |
 
 ## Key DTOs
 
@@ -24,6 +24,12 @@ Core business logic service. Manages problems, bundles, submissions, users, and 
 - `SubmissionDto`, `CreateSubmissionRequest`
 - `CheckResultDto`, `Result`
 - `FileMetadata`, `FileObject`
+
+## Mapper Layer (`mappers/`)
+
+`BundleMapper`, `ProblemMapper`, `SubmissionMapper` are `@Component` assembler beans that own all
+reactive DTO construction (presigned URLs, user-name lookups, status resolution). Controllers inject
+both the relevant service and its mapper; services contain only business logic.
 
 ## Async Messaging (RabbitMQ)
 

--- a/edukate-backend/build.gradle.kts
+++ b/edukate-backend/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     implementation(libs.spring.boot.starter.opentelemetry)
     implementation(libs.logstash.logback.encoder)
     implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.cache)
+    implementation(libs.caffeine)
     implementation(libs.spring.boot.starter.data.mongodb.reactive)
     implementation(libs.springdoc.openapi.starter.webflux.ui)
     implementation(libs.jackson.module.kotlin)

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/configs/CacheConfig.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/configs/CacheConfig.kt
@@ -1,0 +1,27 @@
+package io.github.sanyavertolet.edukate.backend.configs
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+    @Bean
+    fun cacheManager(): CacheManager {
+        val manager = CaffeineCacheManager()
+        manager.setAsyncCacheMode(true)
+        listOf(
+                "problems" to "maximumSize=500,expireAfterWrite=24h",
+                "users-by-id" to "maximumSize=500,expireAfterWrite=10m",
+                "users-by-name" to "maximumSize=500,expireAfterWrite=10m",
+                "bundles" to "maximumSize=200,expireAfterWrite=5m",
+                "presigned-urls" to "maximumSize=1000,expireAfterWrite=30m",
+            )
+            .forEach { (name, spec) -> manager.registerCustomCache(name, Caffeine.from(spec).buildAsync()) }
+        return manager
+    }
+}

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/BundleController.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/BundleController.kt
@@ -6,6 +6,7 @@ import io.github.sanyavertolet.edukate.backend.dtos.ChangeBundleProblemsRequest
 import io.github.sanyavertolet.edukate.backend.dtos.CreateBundleRequest
 import io.github.sanyavertolet.edukate.backend.dtos.UserNameWithRole
 import io.github.sanyavertolet.edukate.backend.entities.Bundle
+import io.github.sanyavertolet.edukate.backend.mappers.BundleMapper
 import io.github.sanyavertolet.edukate.backend.permissions.BundlePermissionEvaluator
 import io.github.sanyavertolet.edukate.backend.services.BundleService
 import io.github.sanyavertolet.edukate.backend.services.UserService
@@ -55,6 +56,7 @@ import reactor.kotlin.core.publisher.toMono
 @Suppress("TooManyFunctions")
 class BundleController(
     private val bundleService: BundleService,
+    private val bundleMapper: BundleMapper,
     private val userService: UserService,
     private val notifier: Notifier,
     private val bundlePermissionEvaluator: BundlePermissionEvaluator,
@@ -82,9 +84,7 @@ class BundleController(
             ],
     )
     fun createBundle(@RequestBody @Valid request: CreateBundleRequest, authentication: Authentication): Mono<BundleDto> =
-        bundleService.createBundle(request, authentication).flatMap { bundle ->
-            bundleService.prepareDto(bundle, authentication)
-        }
+        bundleService.createBundle(request, authentication).flatMap { bundle -> bundleMapper.toDto(bundle, authentication) }
 
     @GetMapping("/owned")
     @PreAuthorize("isAuthenticated()")
@@ -123,9 +123,7 @@ class BundleController(
         @RequestParam(defaultValue = "10") @Positive size: Int,
         authentication: Authentication,
     ): Flux<BundleMetadata> =
-        bundleService.getOwnedBundles(PageRequest.of(page, size), authentication).flatMap {
-            bundleService.prepareMetadata(it)
-        }
+        bundleService.getOwnedBundles(PageRequest.of(page, size), authentication).flatMap { bundleMapper.toMetadata(it) }
 
     @GetMapping("/joined")
     @PreAuthorize("isAuthenticated()")
@@ -164,9 +162,7 @@ class BundleController(
         @RequestParam(defaultValue = "10") @Positive size: Int,
         authentication: Authentication,
     ): Flux<BundleMetadata> =
-        bundleService.getJoinedBundles(PageRequest.of(page, size), authentication).flatMap {
-            bundleService.prepareMetadata(it)
-        }
+        bundleService.getJoinedBundles(PageRequest.of(page, size), authentication).flatMap { bundleMapper.toMetadata(it) }
 
     @GetMapping("/public")
     @SecurityRequirements
@@ -199,7 +195,7 @@ class BundleController(
         @RequestParam(defaultValue = "0") @PositiveOrZero page: Int,
         @RequestParam(defaultValue = "10") @Positive size: Int,
     ): Flux<BundleMetadata> =
-        bundleService.getPublicBundles(PageRequest.of(page, size)).flatMap { bundleService.prepareMetadata(it) }
+        bundleService.getPublicBundles(PageRequest.of(page, size)).flatMap { bundleMapper.toMetadata(it) }
 
     @GetMapping("/{shareCode}")
     @Operation(
@@ -230,30 +226,7 @@ class BundleController(
             .switchIfEmpty(
                 ResponseStatusException(HttpStatus.FORBIDDEN, "Bundle is private and you are not a member.").toMono()
             )
-            .flatMap { bundle -> bundleService.prepareDto(bundle, authentication) }
-
-    @PostMapping("/{shareCode}/join")
-    @PreAuthorize("isAuthenticated()")
-    @SecurityRequirement(name = "cookieAuth")
-    @Operation(summary = "Join a bundle", description = "Joins a bundle using its share code")
-    @ApiResponses(
-        value =
-            [
-                ApiResponse(responseCode = "200", description = "Successfully joined bundle"),
-                ApiResponse(responseCode = "400", description = "Already in bundle"),
-                ApiResponse(responseCode = "401", description = "Unauthorized"),
-                ApiResponse(responseCode = "403", description = "Access denied - invite is required to join"),
-                ApiResponse(responseCode = "404", description = "Bundle not found"),
-            ]
-    )
-    @Parameters(
-        value = [Parameter(name = "shareCode", description = "Bundle share code", `in` = ParameterIn.PATH, required = true)]
-    )
-    fun joinBundle(@PathVariable @NotBlank shareCode: String, authentication: Authentication): Mono<BundleMetadata> =
-        authentication
-            .monoId()
-            .flatMap { userId -> bundleService.joinUser(shareCode, userId) }
-            .flatMap { bundleService.prepareMetadata(it) }
+            .flatMap { bundle -> bundleMapper.toDto(bundle, authentication) }
 
     @PostMapping("/{shareCode}/leave")
     @PreAuthorize("isAuthenticated()")
@@ -401,17 +374,12 @@ class BundleController(
         @RequestParam @NotNull response: Boolean,
         authentication: Authentication,
     ): Mono<String> =
-        response.toMono().flatMap { hasAccepted ->
-            if (hasAccepted) {
-                bundleService
-                    .joinUser(shareCode, requireNotNull(authentication.id()))
-                    .thenReturn("You have accepted invite to bundle $shareCode")
-            } else {
-                bundleService
-                    .declineInvite(shareCode, authentication)
-                    .thenReturn("You have declined invite to bundle $shareCode")
-            }
-        }
+        bundleService
+            .reactToInvite(shareCode, response, authentication)
+            .thenReturn(
+                if (response) "You have accepted invite to bundle $shareCode"
+                else "You have declined invite to bundle $shareCode"
+            )
 
     @GetMapping("/{shareCode}/users")
     @SecurityRequirement(name = "cookieAuth")
@@ -430,7 +398,7 @@ class BundleController(
         value = [Parameter(name = "shareCode", description = "Bundle share code", `in` = ParameterIn.PATH, required = true)]
     )
     fun getUserRoles(@PathVariable @NotBlank shareCode: String, authentication: Authentication): Flux<UserNameWithRole> =
-        bundleService.getBundleUsers(shareCode, authentication)
+        bundleService.getBundleForModerator(shareCode, authentication).flatMapMany { bundleMapper.toUserRoles(it) }
 
     @GetMapping("/{shareCode}/invited-users")
     @SecurityRequirement(name = "cookieAuth")
@@ -452,7 +420,10 @@ class BundleController(
         value = [Parameter(name = "shareCode", description = "Bundle share code", `in` = ParameterIn.PATH, required = true)]
     )
     fun getInvitedUsers(@PathVariable @NotBlank shareCode: String, authentication: Authentication): Mono<List<String>> =
-        bundleService.getBundleInvitedUsers(shareCode, authentication).collectList()
+        bundleService
+            .getBundleForModerator(shareCode, authentication)
+            .flatMapMany { bundleMapper.toInvitedUserNames(it) }
+            .collectList()
 
     @PostMapping("/{shareCode}/role")
     @SecurityRequirement(name = "cookieAuth")
@@ -513,7 +484,7 @@ class BundleController(
         authentication: Authentication,
     ): Mono<BundleDto> =
         bundleService.changeVisibility(shareCode, isPublic, authentication).flatMap { bundle ->
-            bundleService.prepareDto(bundle, authentication)
+            bundleMapper.toDto(bundle, authentication)
         }
 
     @PostMapping("/{shareCode}/problems")
@@ -547,6 +518,6 @@ class BundleController(
         authentication: Authentication,
     ): Mono<BundleDto> =
         bundleService.changeProblems(shareCode, changeBundleProblemsRequest.problemIds, authentication).flatMap { bundle ->
-            bundleService.prepareDto(bundle, authentication)
+            bundleMapper.toDto(bundle, authentication)
         }
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemController.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemController.kt
@@ -4,6 +4,7 @@ import io.github.sanyavertolet.edukate.backend.dtos.ProblemDto
 import io.github.sanyavertolet.edukate.backend.dtos.ProblemMetadata
 import io.github.sanyavertolet.edukate.backend.entities.Problem
 import io.github.sanyavertolet.edukate.backend.filters.ProblemFilter
+import io.github.sanyavertolet.edukate.backend.mappers.ProblemMapper
 import io.github.sanyavertolet.edukate.backend.services.ProblemService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -37,7 +38,7 @@ import reactor.kotlin.core.publisher.toMono
 @SecurityRequirements
 @RequestMapping("/api/v1/problems")
 @Tag(name = "Problems", description = "API for managing and retrieving problems")
-class ProblemController(private val problemService: ProblemService) {
+class ProblemController(private val problemService: ProblemService, private val problemMapper: ProblemMapper) {
     @GetMapping
     @Operation(summary = "Get problem list", description = "Retrieves a paginated list of problem metadata")
     @ApiResponses(
@@ -85,7 +86,7 @@ class ProblemController(private val problemService: ProblemService) {
                 authentication,
                 PageRequest.of(page, size),
             )
-            .flatMapSequential { problem -> problemService.prepareMetadata(problem, authentication) }
+            .flatMapSequential { problem -> problemMapper.toMetadata(problem, authentication) }
 
     @GetMapping("/count")
     @Operation(summary = "Count problems", description = "Returns the total number of problems in the system")
@@ -153,7 +154,7 @@ class ProblemController(private val problemService: ProblemService) {
         problemService
             .findProblemById(id)
             .switchIfEmpty(ResponseStatusException(HttpStatus.NOT_FOUND, "Problem not found").toMono())
-            .flatMap { problem -> problemService.prepareDto(problem, authentication) }
+            .flatMap { problem -> problemMapper.toDto(problem, authentication) }
 
     @Suppress("MaxLineLength")
     @GetMapping("/random")

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/SubmissionController.kt
@@ -2,6 +2,7 @@ package io.github.sanyavertolet.edukate.backend.controllers
 
 import io.github.sanyavertolet.edukate.backend.dtos.CreateSubmissionRequest
 import io.github.sanyavertolet.edukate.backend.dtos.SubmissionDto
+import io.github.sanyavertolet.edukate.backend.mappers.SubmissionMapper
 import io.github.sanyavertolet.edukate.backend.services.ProblemService
 import io.github.sanyavertolet.edukate.backend.services.SubmissionService
 import io.github.sanyavertolet.edukate.backend.services.UserService
@@ -53,6 +54,7 @@ class SubmissionController(
     private val problemService: ProblemService,
     private val userService: UserService,
     private val submissionService: SubmissionService,
+    private val submissionMapper: SubmissionMapper,
     private val fileManager: FileManager,
 ) {
     @GetMapping("/by-id/{id}")
@@ -78,7 +80,7 @@ class SubmissionController(
             .switchIfEmpty(Mono.error(ResponseStatusException(HttpStatus.NOT_FOUND, "Submission not found")))
             .filter { it.userId == authentication.id() }
             .switchIfEmpty(Mono.error(ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied")))
-            .flatMap { submissionService.prepareDto(it) }
+            .flatMap { submissionMapper.toDto(it) }
 
     @PostMapping
     @SecurityRequirement(name = "cookieAuth")
@@ -109,8 +111,9 @@ class SubmissionController(
         @RequestBody @Valid submissionRequest: CreateSubmissionRequest,
         authentication: Authentication,
     ): Mono<SubmissionDto> =
-        userService
-            .findUserByAuthentication(authentication)
+        authentication
+            .monoId()
+            .flatMap { userService.findUserById(it) }
             .switchIfEmpty(ResponseStatusException(HttpStatus.NOT_FOUND, "User not found").toMono())
             .filterWhen { userService.hasUserPermissionToSubmit(it) }
             .switchIfEmpty(ResponseStatusException(HttpStatus.FORBIDDEN, "Not enough permission").toMono())
@@ -125,7 +128,7 @@ class SubmissionController(
                     .switchIfEmpty(ResponseStatusException(HttpStatus.NOT_FOUND, "Could not find files.").toMono())
                     .then(submissionService.saveSubmission(submissionRequest, authentication))
             }
-            .flatMap { submissionService.prepareDto(it) }
+            .flatMap { submissionMapper.toDto(it) }
 
     @PreAuthorize("hasAnyRole('MODERATOR', 'ADMIN')")
     @GetMapping("/{problemId}/{username}")
@@ -176,7 +179,7 @@ class SubmissionController(
                     sortedPageable(page, size),
                 )
             }
-            .flatMapSequential { submissionService.prepareDto(it) }
+            .flatMapSequential { submissionMapper.toDto(it) }
 
     @Suppress("MaxLineLength")
     @GetMapping("/my")
@@ -224,7 +227,7 @@ class SubmissionController(
         authentication
             .monoId()
             .flatMapMany { userId -> submissionService.findUserSubmissions(userId, problemId, sortedPageable(page, size)) }
-            .flatMapSequential { submissionService.prepareDto(it) }
+            .flatMapSequential { submissionMapper.toDto(it) }
 
     private fun sortedPageable(page: Int, size: Int): Pageable = PageRequest.of(page, size, Sort.Direction.DESC, "createdAt")
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/entities/User.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/entities/User.kt
@@ -11,7 +11,7 @@ import org.springframework.data.mongodb.core.mapping.Document
 data class User(
     @field:Id val id: String? = null,
     @field:Indexed(unique = true) val name: String,
-    val email: String,
+    val email: String? = null,
     val token: String,
     val roles: Set<UserRole>,
     val status: UserStatus,

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/BundleMapper.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/BundleMapper.kt
@@ -1,0 +1,39 @@
+package io.github.sanyavertolet.edukate.backend.mappers
+
+import io.github.sanyavertolet.edukate.backend.dtos.BundleDto
+import io.github.sanyavertolet.edukate.backend.dtos.BundleMetadata
+import io.github.sanyavertolet.edukate.backend.dtos.UserNameWithRole
+import io.github.sanyavertolet.edukate.backend.entities.Bundle
+import io.github.sanyavertolet.edukate.backend.services.ProblemService
+import io.github.sanyavertolet.edukate.backend.services.UserService
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+
+@Component
+class BundleMapper(
+    private val problemService: ProblemService,
+    private val problemMapper: ProblemMapper,
+    private val userService: UserService,
+) {
+    fun toDto(bundle: Bundle, authentication: Authentication?): Mono<BundleDto> =
+        problemService
+            .findProblemsByIds(bundle.problemIds)
+            .flatMap { problemMapper.toMetadata(it, authentication) }
+            .collectList()
+            .flatMap { metadataList -> adminNames(bundle).map { admins -> bundle.toDto(metadataList, admins) } }
+
+    fun toMetadata(bundle: Bundle): Mono<BundleMetadata> = adminNames(bundle).map { bundle.toBundleMetadata(it) }
+
+    fun toUserRoles(bundle: Bundle): Flux<UserNameWithRole> =
+        Flux.fromIterable(bundle.userIdRoleMap.keys)
+            .flatMap { userId -> userService.findUserById(userId) }
+            .map { user -> UserNameWithRole(user.name, bundle.userIdRoleMap.getValue(requireNotNull(user.id))) }
+
+    fun toInvitedUserNames(bundle: Bundle): Flux<String> =
+        Flux.fromIterable(bundle.invitedUserIds).flatMap { userService.findUserById(it) }.map { it.name }
+
+    private fun adminNames(bundle: Bundle): Mono<List<String>> =
+        Flux.fromIterable(bundle.getAdminIds()).flatMap { userService.findUserById(it) }.map { it.name }.collectList()
+}

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapper.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapper.kt
@@ -1,0 +1,30 @@
+package io.github.sanyavertolet.edukate.backend.mappers
+
+import io.github.sanyavertolet.edukate.backend.dtos.ProblemDto
+import io.github.sanyavertolet.edukate.backend.dtos.ProblemMetadata
+import io.github.sanyavertolet.edukate.backend.entities.Problem
+import io.github.sanyavertolet.edukate.backend.services.ProblemStatusDecisionManager
+import io.github.sanyavertolet.edukate.backend.services.files.FileManager
+import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.kotlin.core.publisher.toFlux
+
+@Component
+class ProblemMapper(
+    private val problemStatusDecisionManager: ProblemStatusDecisionManager,
+    private val fileManager: FileManager,
+) {
+    fun toDto(problem: Problem, authentication: Authentication?): Mono<ProblemDto> =
+        problemStatusDecisionManager
+            .getStatus(problem.id, authentication)
+            .zipWith(imageUrls(problem).collectList(), problem::toProblemDto)
+
+    fun toMetadata(problem: Problem, authentication: Authentication?): Mono<ProblemMetadata> =
+        problemStatusDecisionManager.getStatus(problem.id, authentication).map { problem.toProblemMetadata(it) }
+
+    private fun imageUrls(problem: Problem): Flux<String> =
+        problem.images.toFlux().map { ProblemFileKey(problem.id, it) }.flatMap { fileManager.getPresignedUrl(it) }
+}

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/SubmissionMapper.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/SubmissionMapper.kt
@@ -1,0 +1,59 @@
+package io.github.sanyavertolet.edukate.backend.mappers
+
+import io.github.sanyavertolet.edukate.backend.dtos.SubmissionDto
+import io.github.sanyavertolet.edukate.backend.entities.Submission
+import io.github.sanyavertolet.edukate.backend.repositories.FileObjectRepository
+import io.github.sanyavertolet.edukate.backend.services.ProblemService
+import io.github.sanyavertolet.edukate.backend.services.UserService
+import io.github.sanyavertolet.edukate.backend.services.files.FileManager
+import io.github.sanyavertolet.edukate.common.checks.SubmissionContext
+import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
+import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
+
+@Component
+class SubmissionMapper(
+    private val fileObjectRepository: FileObjectRepository,
+    private val fileManager: FileManager,
+    private val userService: UserService,
+    private val problemService: ProblemService,
+) {
+    fun toDto(submission: Submission): Mono<SubmissionDto> =
+        collectFileUrls(submission).zipWith(
+            userService.findUserById(submission.userId).map { it.name }.defaultIfEmpty("UNKNOWN")
+        ) { fileUrls, userName ->
+            SubmissionDto(
+                requireNotNull(submission.id) { "Submission ID cannot be null" },
+                submission.problemId,
+                userName,
+                submission.status,
+                requireNotNull(submission.createdAt) { "Submission creation timestamp cannot be null" },
+                fileUrls,
+            )
+        }
+
+    fun prepareContext(submission: Submission): Mono<SubmissionContext> =
+        problemService.findProblemById(submission.problemId).flatMap { problem ->
+            val problemRawKeys = problem.images.map { ProblemFileKey(problem.id, it).toString() }
+            fileObjectRepository
+                .findAllById(submission.fileObjectIds)
+                .map { it.keyPath }
+                .collectList()
+                .map { submissionRawKeys ->
+                    SubmissionContext(
+                        requireNotNull(submission.id) { "Submission id must not be null" },
+                        problem.id,
+                        problem.text,
+                        problemRawKeys,
+                        submissionRawKeys,
+                    )
+                }
+        }
+
+    private fun collectFileUrls(submission: Submission): Mono<List<String>> =
+        fileObjectRepository
+            .findAllById(submission.fileObjectIds)
+            .map { it.key }
+            .flatMapSequential { fileManager.getPresignedUrl(it) }
+            .collectList()
+}

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/BundleService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/BundleService.kt
@@ -1,38 +1,35 @@
 package io.github.sanyavertolet.edukate.backend.services
 
-import io.github.sanyavertolet.edukate.backend.dtos.BundleDto
-import io.github.sanyavertolet.edukate.backend.dtos.BundleMetadata
 import io.github.sanyavertolet.edukate.backend.dtos.CreateBundleRequest
-import io.github.sanyavertolet.edukate.backend.dtos.UserNameWithRole
 import io.github.sanyavertolet.edukate.backend.entities.Bundle
 import io.github.sanyavertolet.edukate.backend.permissions.BundlePermissionEvaluator
 import io.github.sanyavertolet.edukate.backend.repositories.BundleRepository
 import io.github.sanyavertolet.edukate.common.users.UserRole
+import io.github.sanyavertolet.edukate.common.utils.badRequestIf
+import io.github.sanyavertolet.edukate.common.utils.forbiddenIf
 import io.github.sanyavertolet.edukate.common.utils.id
 import io.github.sanyavertolet.edukate.common.utils.monoId
+import io.github.sanyavertolet.edukate.common.utils.notFoundIf
+import io.github.sanyavertolet.edukate.common.utils.orNotFound
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.PageRequest
-import org.springframework.http.HttpStatus
 import org.springframework.security.core.Authentication
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.toMono
 
 @Service
+@CacheConfig(cacheNames = ["bundles"])
 @Suppress("TooManyFunctions")
 class BundleService(
     private val bundleRepository: BundleRepository,
     private val shareCodeGenerator: ShareCodeGenerator,
-    private val problemService: ProblemService,
     private val bundlePermissionEvaluator: BundlePermissionEvaluator,
-    private val userService: UserService,
 ) {
-    fun findBundleByShareCode(shareCode: String): Mono<Bundle> =
-        bundleRepository
-            .findBundleByShareCode(shareCode)
-            .switchIfEmpty(ResponseStatusException(HttpStatus.NOT_FOUND, "Bundle [$shareCode] not found").toMono())
+    @Cacheable(key = "#shareCode") fun findBundleByShareCode(shareCode: String): Mono<Bundle> = loadBundle(shareCode)
 
     fun getOwnedBundles(pageable: PageRequest, authentication: Authentication): Flux<Bundle> =
         authentication.monoId().flatMapMany { userId ->
@@ -52,75 +49,60 @@ class BundleService(
             .map { userId -> Bundle.fromCreateRequest(createBundleRequest, userId, shareCodeGenerator.generateShareCode()) }
             .flatMap { bundleRepository.save(it) }
 
-    @Transactional
-    fun joinUser(shareCode: String, userId: String): Mono<Bundle> =
-        findBundleByShareCode(shareCode)
-            .filter { bundlePermissionEvaluator.hasJoinPermission(it, userId) }
-            .switchIfEmpty(
-                ResponseStatusException(HttpStatus.FORBIDDEN, "To join this bundle, you should be invited").toMono()
-            )
-            .filter { !it.isUserInBundle(userId) }
-            .switchIfEmpty(
-                ResponseStatusException(HttpStatus.BAD_REQUEST, "You have already joined the bundle [$shareCode]").toMono()
-            )
-            .map { it.withJoinedUser(userId, UserRole.USER) }
-            .flatMap { bundleRepository.save(it) }
-
+    @CacheEvict(key = "#shareCode")
     @Transactional
     fun removeUser(shareCode: String, userId: String): Mono<Bundle> =
-        findBundleByShareCode(shareCode)
-            .filter { it.isUserInBundle(userId) }
-            .switchIfEmpty(ResponseStatusException(HttpStatus.BAD_REQUEST, "User is not in bundle").toMono())
-            .filter { !it.isAdmin(userId) || it.getAdminIds().size > 1 }
-            .switchIfEmpty(
-                ResponseStatusException(HttpStatus.BAD_REQUEST, "Last admin should delete bundle, not leave it").toMono()
-            )
-            .map { it.withoutUser(userId) }
-            .flatMap { bundleRepository.save(it) }
+        mutate(shareCode, { it.withoutUser(userId) }) { mono ->
+            mono
+                .badRequestIf("User is not in bundle") { !it.isUserInBundle(userId) }
+                .badRequestIf("Last admin should delete bundle, not leave it") {
+                    it.isAdmin(userId) && it.getAdminIds().size == 1
+                }
+        }
 
+    @CacheEvict(key = "#shareCode")
     @Transactional
     fun inviteUser(shareCode: String, inviterId: String, inviteeId: String): Mono<Bundle> =
-        findBundleByShareCode(shareCode)
-            .filter { bundlePermissionEvaluator.hasInvitePermission(it, inviterId) }
-            .switchIfEmpty(ResponseStatusException(HttpStatus.FORBIDDEN, "Not enough permissions to invite").toMono())
-            .filter { !it.isUserInBundle(inviteeId) }
-            .switchIfEmpty(ResponseStatusException(HttpStatus.BAD_REQUEST, "User is already in bundle").toMono())
-            .map { it.withInvitedUser(inviteeId) }
-            .flatMap { bundleRepository.save(it) }
+        mutate(shareCode, { it.withInvitedUser(inviteeId) }) { mono ->
+            mono
+                .forbiddenIf("Not enough permissions to invite") {
+                    !bundlePermissionEvaluator.hasInvitePermission(it, inviterId)
+                }
+                .badRequestIf("User is already in bundle") { it.isUserInBundle(inviteeId) }
+        }
 
+    @CacheEvict(key = "#shareCode")
     @Transactional
     fun expireInvite(shareCode: String, inviterId: String, inviteeId: String): Mono<Bundle> =
-        findBundleByShareCode(shareCode)
-            .filter { bundlePermissionEvaluator.hasInvitePermission(it, inviterId) }
-            .switchIfEmpty(ResponseStatusException(HttpStatus.FORBIDDEN, "Not enough permissions to expire invite").toMono())
-            .filter { it.isUserInvited(inviteeId) }
-            .switchIfEmpty(ResponseStatusException(HttpStatus.BAD_REQUEST, "User is not invited to this bundle").toMono())
-            .map { it.withoutInvitedUser(inviteeId) }
-            .flatMap { bundleRepository.save(it) }
-
-    @Transactional
-    fun getBundleUsers(shareCode: String, authentication: Authentication): Flux<UserNameWithRole> =
-        findBundleByShareCode(shareCode)
-            .filter {
-                val requesterId = requireNotNull(authentication.id())
-                bundlePermissionEvaluator.hasRole(it, requesterId, UserRole.MODERATOR)
-            }
-            .flatMapMany { bundle ->
-                val userIdRoleMap = bundle.userIdRoleMap
-                userService.findUsersByIds(userIdRoleMap.keys).map { user ->
-                    UserNameWithRole(user.name, userIdRoleMap.getValue(requireNotNull(user.id)))
+        mutate(shareCode, { it.withoutInvitedUser(inviteeId) }) { mono ->
+            mono
+                .forbiddenIf("Not enough permissions to expire invite") {
+                    !bundlePermissionEvaluator.hasInvitePermission(it, inviterId)
                 }
-            }
+                .badRequestIf("User is not invited to this bundle") { !it.isUserInvited(inviteeId) }
+        }
 
+    @CacheEvict(key = "#shareCode")
     @Transactional
-    fun getBundleInvitedUsers(shareCode: String, authentication: Authentication): Flux<String> =
-        findBundleByShareCode(shareCode)
-            .filter {
-                val requesterId = requireNotNull(authentication.id())
-                bundlePermissionEvaluator.hasRole(it, requesterId, UserRole.MODERATOR)
+    fun reactToInvite(shareCode: String, accepted: Boolean, authentication: Authentication): Mono<Bundle> {
+        val userId = requireNotNull(authentication.id())
+        return mutate(
+            shareCode,
+            { if (accepted) it.withJoinedUser(userId, UserRole.USER) else it.withoutInvitedUser(userId) },
+        ) { mono ->
+            mono.forbiddenIf("You cannot react to the invitation as nobody has invited you yet") {
+                !it.isUserInvited(userId)
             }
-            .flatMapMany { bundle -> userService.findUsersByIds(bundle.invitedUserIds).map { it.name } }
+        }
+    }
 
+    @Transactional(readOnly = true)
+    fun getBundleForModerator(shareCode: String, authentication: Authentication): Mono<Bundle> =
+        loadBundle(shareCode).forbiddenIf("You are not allowed to view this bundle") {
+            !bundlePermissionEvaluator.hasRole(it, UserRole.MODERATOR, authentication)
+        }
+
+    @CacheEvict(key = "#shareCode")
     @Transactional
     fun changeUserRole(
         shareCode: String,
@@ -128,68 +110,44 @@ class BundleService(
         requestedRole: UserRole,
         authentication: Authentication,
     ): Mono<UserRole> =
-        findBundleByShareCode(shareCode)
-            .filter { it.isUserInBundle(userId) }
-            .switchIfEmpty(ResponseStatusException(HttpStatus.NOT_FOUND, "Target user not found in bundle").toMono())
-            .filter {
-                val requesterId = requireNotNull(authentication.id())
-                bundlePermissionEvaluator.hasChangeRolePermission(it, requesterId, userId, requestedRole)
+        mutate(shareCode, { it.withUserRole(userId, requestedRole) }) { mono ->
+                mono
+                    .notFoundIf("Target user not found in bundle") { !it.isUserInBundle(userId) }
+                    .forbiddenIf("Cannot set $userId role to be $requestedRole") {
+                        !bundlePermissionEvaluator.hasChangeRolePermission(
+                            it,
+                            requireNotNull(authentication.id()),
+                            userId,
+                            requestedRole,
+                        )
+                    }
             }
-            .switchIfEmpty(
-                ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot set $userId role to be $requestedRole").toMono()
-            )
-            .map { it.withUserRole(userId, requestedRole) }
-            .flatMap { bundleRepository.save(it) }
             .thenReturn(requestedRole)
 
-    @Transactional
-    fun declineInvite(shareCode: String, authentication: Authentication): Mono<Bundle> =
-        findBundleByShareCode(shareCode)
-            .filter { it.isUserInvited(requireNotNull(authentication.id())) }
-            .switchIfEmpty(
-                ResponseStatusException(
-                        HttpStatus.FORBIDDEN,
-                        "You cannot decline the invitation as nobody has invited you yet",
-                    )
-                    .toMono()
-            )
-            .map { it.withoutInvitedUser(requireNotNull(authentication.id())) }
-            .flatMap { bundleRepository.save(it) }
-
+    @CacheEvict(key = "#shareCode")
     @Transactional
     fun changeVisibility(shareCode: String, isPublic: Boolean, authentication: Authentication): Mono<Bundle> =
-        findBundleByShareCode(shareCode)
-            .filter { bundlePermissionEvaluator.hasRole(it, UserRole.MODERATOR, authentication) }
-            .switchIfEmpty(
-                ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot change visibility due to lack of permissions").toMono()
-            )
-            .map { it.withVisibility(isPublic) }
-            .flatMap { bundleRepository.save(it) }
+        mutate(shareCode, { it.withVisibility(isPublic) }) { mono ->
+            mono.forbiddenIf("Cannot change visibility due to lack of permissions") {
+                !bundlePermissionEvaluator.hasRole(it, UserRole.MODERATOR, authentication)
+            }
+        }
 
+    @CacheEvict(key = "#shareCode")
     @Transactional
     fun changeProblems(shareCode: String, problemIds: List<String>, authentication: Authentication): Mono<Bundle> =
-        shareCode
-            .toMono()
-            .filter { problemIds.isNotEmpty() }
-            .switchIfEmpty(ResponseStatusException(HttpStatus.BAD_REQUEST, "Bundle problem list cannot be empty").toMono())
-            .flatMap { findBundleByShareCode(it) }
-            .filter { bundlePermissionEvaluator.hasRole(it, UserRole.MODERATOR, authentication) }
-            .switchIfEmpty(
-                ResponseStatusException(HttpStatus.FORBIDDEN, "Cannot change problem list due to lack of permissions")
-                    .toMono()
-            )
-            .map { it.withProblemIds(problemIds) }
-            .flatMap { bundleRepository.save(it) }
+        mutate(shareCode, { it.withProblemIds(problemIds) }) { mono ->
+            mono.forbiddenIf("Cannot change problem list due to lack of permissions") {
+                !bundlePermissionEvaluator.hasRole(it, UserRole.MODERATOR, authentication)
+            }
+        }
 
-    fun prepareDto(bundle: Bundle, authentication: Authentication?): Mono<BundleDto> =
-        problemService
-            .findProblemsByIds(bundle.problemIds)
-            .flatMap { problem -> problemService.prepareMetadata(problem, authentication) }
-            .collectList()
-            .flatMap { metadataList -> getAdmins(bundle).map { admins -> bundle.toDto(metadataList, admins) } }
+    private fun loadBundle(shareCode: String): Mono<Bundle> =
+        bundleRepository.findBundleByShareCode(shareCode).orNotFound("Bundle [$shareCode] not found")
 
-    fun prepareMetadata(bundle: Bundle): Mono<BundleMetadata> = getAdmins(bundle).map { bundle.toBundleMetadata(it) }
-
-    private fun getAdmins(bundle: Bundle): Mono<List<String>> =
-        userService.findUsersByIds(bundle.getAdminIds()).map { it.name }.collectList()
+    private fun mutate(
+        shareCode: String,
+        transform: (Bundle) -> Bundle,
+        validate: (Mono<Bundle>) -> Mono<Bundle>,
+    ): Mono<Bundle> = validate(loadBundle(shareCode)).map { transform(it) }.flatMap { bundleRepository.save(it) }
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/CheckerSchedulerService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/CheckerSchedulerService.kt
@@ -1,6 +1,7 @@
 package io.github.sanyavertolet.edukate.backend.services
 
 import io.github.sanyavertolet.edukate.backend.entities.Submission
+import io.github.sanyavertolet.edukate.backend.mappers.SubmissionMapper
 import io.github.sanyavertolet.edukate.messaging.RabbitTopology
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.stereotype.Component
@@ -8,9 +9,9 @@ import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
 @Component
-class CheckerSchedulerService(private val rabbitTemplate: RabbitTemplate, private val submissionService: SubmissionService) {
+class CheckerSchedulerService(private val rabbitTemplate: RabbitTemplate, private val submissionMapper: SubmissionMapper) {
     fun scheduleCheck(submission: Submission): Mono<Void> =
-        submissionService.prepareContext(submission).publishOn(Schedulers.boundedElastic()).flatMap { ctx ->
+        submissionMapper.prepareContext(submission).publishOn(Schedulers.boundedElastic()).flatMap { ctx ->
             Mono.fromRunnable { rabbitTemplate.convertAndSend(RabbitTopology.EXCHANGE, RabbitTopology.Rk.SCHEDULE, ctx) }
         }
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/ProblemService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/ProblemService.kt
@@ -1,16 +1,15 @@
 package io.github.sanyavertolet.edukate.backend.services
 
-import io.github.sanyavertolet.edukate.backend.dtos.ProblemDto
-import io.github.sanyavertolet.edukate.backend.dtos.ProblemMetadata
 import io.github.sanyavertolet.edukate.backend.entities.Problem
 import io.github.sanyavertolet.edukate.backend.filters.ProblemFilter
 import io.github.sanyavertolet.edukate.backend.repositories.ProblemRepository
-import io.github.sanyavertolet.edukate.backend.services.files.FileManager
 import io.github.sanyavertolet.edukate.backend.utils.SemVerUtils.semVerSort
 import io.github.sanyavertolet.edukate.common.SubmissionStatus
 import io.github.sanyavertolet.edukate.common.utils.monoId
-import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
 import org.bson.Document
+import org.springframework.cache.annotation.CacheConfig
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.mongodb.core.ReactiveMongoTemplate
@@ -24,17 +23,12 @@ import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import reactor.kotlin.core.publisher.toFlux
 import reactor.kotlin.core.publisher.toMono
 
 @Service
+@CacheConfig(cacheNames = ["problems"])
 @Suppress("TooManyFunctions")
-class ProblemService(
-    private val problemRepository: ProblemRepository,
-    private val mongoTemplate: ReactiveMongoTemplate,
-    private val fileManager: FileManager,
-    private val problemStatusDecisionManager: ProblemStatusDecisionManager,
-) {
+class ProblemService(private val problemRepository: ProblemRepository, private val mongoTemplate: ReactiveMongoTemplate) {
     fun getFilteredProblems(
         filter: ProblemFilter,
         authentication: Authentication?,
@@ -72,15 +66,16 @@ class ProblemService(
         }
     }
 
-    fun findProblemById(id: String): Mono<Problem> = problemRepository.findById(id)
+    @Cacheable(key = "#id") fun findProblemById(id: String): Mono<Problem> = problemRepository.findById(id)
 
     fun findProblemsByIds(problemIds: List<String>): Flux<Problem> = problemRepository.findProblemsByIdIn(problemIds)
 
-    fun updateProblem(problem: Problem): Mono<Problem> = problemRepository.save(problem)
+    @CacheEvict(key = "#problem.id") fun updateProblem(problem: Problem): Mono<Problem> = problemRepository.save(problem)
 
+    @CacheEvict(allEntries = true)
     fun updateProblemBatch(problems: Flux<Problem>): Mono<Long> = problemRepository.saveAll(problems).count()
 
-    fun deleteProblemById(id: String): Mono<Void> = problemRepository.deleteById(id)
+    @CacheEvict(key = "#id") fun deleteProblemById(id: String): Mono<Void> = problemRepository.deleteById(id)
 
     fun getProblemIdsByPrefix(prefix: String, limit: Int): Flux<String> =
         problemRepository.findProblemsByIdStartingWith(prefix, Pageable.ofSize(limit)).map { it.id }
@@ -90,17 +85,6 @@ class ProblemService(
             .monoId()
             .flatMap { problemRepository.findRandomUnsolvedProblemId(it) }
             .switchIfEmpty(problemRepository.findRandomProblemId())
-
-    fun problemImageDownloadUrls(problemId: String, images: List<String>): Flux<String> =
-        images.toFlux().map { fileName -> ProblemFileKey(problemId, fileName) }.flatMap { fileManager.getPresignedUrl(it) }
-
-    fun prepareDto(problem: Problem, authentication: Authentication?): Mono<ProblemDto> =
-        problemStatusDecisionManager
-            .getStatus(problem.id, authentication)
-            .zipWith(problemImageDownloadUrls(problem.id, problem.images).collectList(), problem::toProblemDto)
-
-    fun prepareMetadata(problem: Problem, authentication: Authentication?): Mono<ProblemMetadata> =
-        problemStatusDecisionManager.getStatus(problem.id, authentication).map { problem.toProblemMetadata(it) }
 
     private fun findByFilter(filter: ProblemFilter, userId: String?, pageRequest: PageRequest): Flux<Problem> {
         val operations = buildFilterStages(filter, userId)

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/ResultService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/ResultService.kt
@@ -4,6 +4,7 @@ import io.github.sanyavertolet.edukate.backend.dtos.Result
 import io.github.sanyavertolet.edukate.backend.repositories.ProblemRepository
 import io.github.sanyavertolet.edukate.backend.services.files.FileManager
 import io.github.sanyavertolet.edukate.storage.keys.ResultFileKey
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -15,13 +16,15 @@ import reactor.kotlin.core.publisher.toMono
  * todo: refactor Result entity in order to split the persistent result with human readable result (with correct pics)
  */
 class ResultService(private val problemRepository: ProblemRepository, private val fileManager: FileManager) {
-    fun updateResult(result: Result): Mono<String> =
+    @CacheEvict(cacheNames = ["problems"], key = "#problemResult.id")
+    fun updateResult(problemResult: Result): Mono<String> =
         problemRepository
-            .findById(result.id)
-            .map { problem -> problem.copy(result = result) }
+            .findById(problemResult.id)
+            .map { problem -> problem.copy(result = problemResult) }
             .flatMap { problemRepository.save(it) }
             .map { it.id }
 
+    @CacheEvict(cacheNames = ["problems"], allEntries = true)
     fun updateResultBatch(results: Flux<Result>): Mono<Long> =
         results
             .flatMap { result ->

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/SubmissionService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/SubmissionService.kt
@@ -1,17 +1,13 @@
 package io.github.sanyavertolet.edukate.backend.services
 
 import io.github.sanyavertolet.edukate.backend.dtos.CreateSubmissionRequest
-import io.github.sanyavertolet.edukate.backend.dtos.SubmissionDto
 import io.github.sanyavertolet.edukate.backend.entities.Submission
 import io.github.sanyavertolet.edukate.backend.permissions.SubmissionPermissionEvaluator
 import io.github.sanyavertolet.edukate.backend.repositories.FileObjectRepository
 import io.github.sanyavertolet.edukate.backend.repositories.SubmissionRepository
-import io.github.sanyavertolet.edukate.backend.services.files.FileManager
 import io.github.sanyavertolet.edukate.backend.services.files.SubmissionFileService
 import io.github.sanyavertolet.edukate.common.SubmissionStatus
-import io.github.sanyavertolet.edukate.common.checks.SubmissionContext
 import io.github.sanyavertolet.edukate.common.utils.monoId
-import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
 import io.github.sanyavertolet.edukate.storage.keys.SubmissionFileKey
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.data.domain.Pageable
@@ -28,11 +24,8 @@ import reactor.kotlin.core.publisher.toMono
 @Service
 class SubmissionService(
     private val submissionRepository: SubmissionRepository,
-    private val fileManager: FileManager,
     private val submissionFileService: SubmissionFileService,
-    private val userService: UserService,
     private val fileObjectRepository: FileObjectRepository,
-    private val problemService: ProblemService,
     private val submissionPermissionEvaluator: SubmissionPermissionEvaluator,
     private val meterRegistry: MeterRegistry,
 ) {
@@ -70,11 +63,8 @@ class SubmissionService(
 
     /** If problemId is null, then returns submissions by user id regardless of the problem. */
     fun findUserSubmissions(userId: String, problemId: String?, pageable: Pageable): Flux<Submission> =
-        if (problemId != null) {
-            submissionRepository.findAllByProblemIdAndUserId(problemId, userId, pageable)
-        } else {
-            submissionRepository.findAllByUserId(userId, pageable)
-        }
+        problemId?.let { submissionRepository.findAllByProblemIdAndUserId(it, userId, pageable) }
+            ?: submissionRepository.findAllByUserId(userId, pageable)
 
     fun findSubmissionsByStatusIn(statuses: List<SubmissionStatus>, pageable: Pageable): Flux<Submission> =
         submissionRepository.findAllByStatusIn(statuses, pageable)
@@ -85,44 +75,4 @@ class SubmissionService(
             .switchIfEmpty(ResponseStatusException(HttpStatus.NOT_FOUND, "Submission not found").toMono())
             .filter { submission -> submissionPermissionEvaluator.isOwner(submission, userId) }
             .switchIfEmpty(ResponseStatusException(HttpStatus.FORBIDDEN, "Access denied").toMono())
-
-    fun prepareDto(submission: Submission): Mono<SubmissionDto> =
-        collectFileUrls(submission).zipWith(userService.findUserName(submission.userId)) { fileUrls, userName ->
-            SubmissionDto(
-                requireNotNull(submission.id) { "Submission ID cannot be null" },
-                submission.problemId,
-                userName,
-                submission.status,
-                requireNotNull(submission.createdAt) { "Submission creation timestamp cannot be null" },
-                fileUrls,
-            )
-        }
-
-    private fun collectFileUrls(submission: Submission): Mono<List<String>> =
-        fileObjectRepository
-            .findAllById(submission.fileObjectIds)
-            .map { it.key }
-            .flatMapSequential { fileManager.getPresignedUrl(it) }
-            .collectList()
-
-    fun prepareContext(submission: Submission): Mono<SubmissionContext> =
-        problemService.findProblemById(submission.problemId).flatMap { problem ->
-            val problemText = problem.text
-            val problemRawKeys =
-                problem.images.map { fileName -> ProblemFileKey(problem.id, fileName) }.map { it.toString() }
-
-            fileManager
-                .getFileObjectsByIds(submission.fileObjectIds)
-                .map { it.keyPath }
-                .collectList()
-                .map { submissionRawKeys ->
-                    SubmissionContext(
-                        requireNotNull(submission.id) { "Submission id must not be null" },
-                        problem.id,
-                        problemText,
-                        problemRawKeys,
-                        submissionRawKeys,
-                    )
-                }
-        }
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/UserService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/UserService.kt
@@ -5,31 +5,39 @@ import io.github.sanyavertolet.edukate.backend.repositories.UserRepository
 import io.github.sanyavertolet.edukate.common.notifications.SimpleNotificationCreateRequest
 import io.github.sanyavertolet.edukate.common.services.Notifier
 import io.github.sanyavertolet.edukate.common.users.UserStatus
-import io.github.sanyavertolet.edukate.common.utils.monoId
 import java.util.UUID
 import org.slf4j.LoggerFactory
-import org.springframework.security.core.Authentication
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.cache.annotation.Caching
 import org.springframework.stereotype.Service
-import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
 
 @Service
 class UserService(private val userRepository: UserRepository, private val notifier: Notifier) {
-    fun findUserByAuthentication(authentication: Authentication): Mono<User> =
-        authentication.monoId().flatMap { findUserById(it) }
-
+    @Caching(
+        evict =
+            [
+                CacheEvict(cacheNames = ["users-by-id"], key = "#user.id"),
+                CacheEvict(cacheNames = ["users-by-name"], key = "#user.name"),
+            ]
+    )
     fun saveUser(user: User): Mono<User> = userRepository.save(user)
 
+    @Cacheable(cacheNames = ["users-by-id"], key = "#userId")
     fun findUserById(userId: String): Mono<User> = userRepository.findById(userId)
 
-    fun findUserName(userId: String): Mono<String> =
-        userRepository.findById(userId).map { it.name }.defaultIfEmpty(DEFAULT_USER_NAME)
-
-    fun findUsersByIds(userIds: Collection<String>): Flux<User> = userRepository.findAllById(userIds)
-
+    @Cacheable(cacheNames = ["users-by-name"], key = "#name")
     fun findUserByName(name: String): Mono<User> = userRepository.findByName(name)
 
+    @Caching(
+        evict =
+            [
+                CacheEvict(cacheNames = ["users-by-id"], key = "#id"),
+                CacheEvict(cacheNames = ["users-by-name"], allEntries = true),
+            ]
+    )
     fun deleteUserById(id: String): Mono<Void> = userRepository.deleteById(id)
 
     fun hasUserPermissionToSubmit(user: User): Mono<Boolean> = (user.status == UserStatus.ACTIVE).toMono()
@@ -55,7 +63,6 @@ class UserService(private val userRepository: UserRepository, private val notifi
             .count()
 
     companion object {
-        private const val DEFAULT_USER_NAME = "UNKNOWN"
         private val log = LoggerFactory.getLogger(UserService::class.java)
     }
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/files/FileManager.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/files/FileManager.kt
@@ -9,6 +9,8 @@ import io.github.sanyavertolet.edukate.storage.keys.FileKey
 import java.nio.ByteBuffer
 import java.time.Duration
 import org.slf4j.LoggerFactory
+import org.springframework.cache.annotation.CacheEvict
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -33,12 +35,11 @@ class FileManager(private val fileObjectRepository: FileObjectRepository, privat
             .doOnSubscribe { log.debug("Downloading content: key={}", key) }
             .doOnError { e -> log.error("download failed for key={}", key, e) }
 
+    @Cacheable(cacheNames = ["presigned-urls"], key = "#key.toString()")
     fun getPresignedUrl(key: FileKey): Mono<String> =
         storage.generatePresignedUrl(key).timeout(DEFAULT_TIMEOUT).doOnError { e ->
             log.error("presign failed for key={}", key, e)
         }
-
-    fun getFileObjectsByIds(ids: List<String>): Flux<FileObject> = fileObjectRepository.findAllById(ids)
 
     @Transactional
     fun uploadFile(key: FileKey, contentType: MediaType, content: Flux<ByteBuffer>): Mono<FileKey> =
@@ -52,6 +53,7 @@ class FileManager(private val fileObjectRepository: FileObjectRepository, privat
             .doOnSuccess { k -> log.debug("Uploaded: key={}", k) }
             .doOnError { e -> log.error("upload failed for key={}", key, e) }
 
+    @CacheEvict(cacheNames = ["presigned-urls"], key = "#key.toString()")
     @Transactional
     fun deleteFile(key: FileKey): Mono<Boolean> =
         storage
@@ -91,6 +93,7 @@ class FileManager(private val fileObjectRepository: FileObjectRepository, privat
             .timeout(DEFAULT_TIMEOUT)
             .doOnError { e -> log.error("batch exists check failed", e) }
 
+    @CacheEvict(cacheNames = ["presigned-urls"], key = "#oldKey.toString()")
     @Transactional
     fun moveFile(oldKey: FileKey, newKey: FileKey): Mono<FileKey> =
         storage

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/BundleControllerIntegrationTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/BundleControllerIntegrationTest.kt
@@ -99,48 +99,6 @@ class BundleControllerIntegrationTest : AbstractBackendIntegrationTest() {
 
     // endregion
 
-    // region POST /api/v1/bundles/{shareCode}/join
-
-    @Test
-    fun `joinBundle returns 200 for public bundle`() {
-        bundleRepository
-            .save(
-                BackendFixtures.bundle(
-                    isPublic = true,
-                    shareCode = "SC-JOIN",
-                    userIdRoleMap = mapOf("other-user" to UserRole.ADMIN),
-                )
-            )
-            .block()
-
-        authenticatedClient()
-            .post()
-            .uri("/api/v1/bundles/SC-JOIN/join")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.shareCode")
-            .isEqualTo("SC-JOIN")
-    }
-
-    @Test
-    fun `joinBundle returns 400 when already a member`() {
-        bundleRepository
-            .save(
-                BackendFixtures.bundle(
-                    isPublic = true,
-                    shareCode = "SC-JOINED",
-                    userIdRoleMap = mapOf("user-1" to UserRole.ADMIN),
-                )
-            )
-            .block()
-
-        authenticatedClient().post().uri("/api/v1/bundles/SC-JOINED/join").exchange().expectStatus().isBadRequest
-    }
-
-    // endregion
-
     // region POST /api/v1/bundles/{shareCode}/leave
 
     @Test

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/BundleControllerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/BundleControllerTest.kt
@@ -9,6 +9,7 @@ import io.github.sanyavertolet.edukate.backend.dtos.BundleMetadata
 import io.github.sanyavertolet.edukate.backend.dtos.ChangeBundleProblemsRequest
 import io.github.sanyavertolet.edukate.backend.dtos.CreateBundleRequest
 import io.github.sanyavertolet.edukate.backend.dtos.UserNameWithRole
+import io.github.sanyavertolet.edukate.backend.mappers.BundleMapper
 import io.github.sanyavertolet.edukate.backend.permissions.BundlePermissionEvaluator
 import io.github.sanyavertolet.edukate.backend.services.BundleService
 import io.github.sanyavertolet.edukate.backend.services.UserService
@@ -24,6 +25,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.security.test.web.reactive.server.SecurityMockServerConfigurers
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBodyList
 import org.springframework.web.server.ResponseStatusException
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -35,6 +37,7 @@ class BundleControllerTest {
     @Autowired private lateinit var webTestClient: WebTestClient
 
     @MockkBean private lateinit var bundleService: BundleService
+    @MockkBean private lateinit var bundleMapper: BundleMapper
     @MockkBean private lateinit var userService: UserService
     @MockkBean private lateinit var notifier: Notifier
     @MockkBean private lateinit var bundlePermissionEvaluator: BundlePermissionEvaluator
@@ -56,7 +59,7 @@ class BundleControllerTest {
     fun `createBundle returns 200 with bundle DTO`() {
         val bundle = BackendFixtures.bundle()
         every { bundleService.createBundle(any(), any()) } returns Mono.just(bundle)
-        every { bundleService.prepareDto(bundle, any()) } returns Mono.just(bundleDto())
+        every { bundleMapper.toDto(bundle, any()) } returns Mono.just(bundleDto())
 
         authenticatedClient()
             .post()
@@ -81,7 +84,7 @@ class BundleControllerTest {
     fun `getPublicBundles returns 200 with metadata list (no auth required)`() {
         val bundle = BackendFixtures.bundle(isPublic = true)
         every { bundleService.getPublicBundles(any()) } returns Flux.just(bundle)
-        every { bundleService.prepareMetadata(bundle) } returns Mono.just(bundleMetadata())
+        every { bundleMapper.toMetadata(bundle) } returns Mono.just(bundleMetadata())
 
         webTestClient
             .get()
@@ -89,7 +92,7 @@ class BundleControllerTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBodyList(BundleMetadata::class.java)
+            .expectBodyList<BundleMetadata>()
             .hasSize(1)
     }
 
@@ -101,7 +104,7 @@ class BundleControllerTest {
     fun `getOwnedBundles returns 200 with owned bundle metadata`() {
         val bundle = BackendFixtures.bundle()
         every { bundleService.getOwnedBundles(any(), any()) } returns Flux.just(bundle)
-        every { bundleService.prepareMetadata(bundle) } returns Mono.just(bundleMetadata())
+        every { bundleMapper.toMetadata(bundle) } returns Mono.just(bundleMetadata())
 
         authenticatedClient()
             .get()
@@ -109,7 +112,7 @@ class BundleControllerTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBodyList(BundleMetadata::class.java)
+            .expectBodyList<BundleMetadata>()
             .hasSize(1)
     }
 
@@ -122,7 +125,7 @@ class BundleControllerTest {
         val bundle = BackendFixtures.bundle(userIdRoleMap = mapOf("user-1" to UserRole.USER))
         every { bundleService.findBundleByShareCode("SHARE123") } returns Mono.just(bundle)
         every { bundlePermissionEvaluator.hasReadPermission(bundle, "user-1") } returns true
-        every { bundleService.prepareDto(bundle, any()) } returns Mono.just(bundleDto())
+        every { bundleMapper.toDto(bundle, any()) } returns Mono.just(bundleDto())
 
         authenticatedClient()
             .get()
@@ -146,34 +149,13 @@ class BundleControllerTest {
 
     // endregion
 
-    // region POST /api/v1/bundles/{shareCode}/join
-
-    @Test
-    fun `joinBundle returns 200 with bundle metadata`() {
-        val bundle = BackendFixtures.bundle()
-        every { bundleService.joinUser("SHARE123", "user-1") } returns Mono.just(bundle)
-        every { bundleService.prepareMetadata(bundle) } returns Mono.just(bundleMetadata())
-
-        authenticatedClient()
-            .post()
-            .uri("/api/v1/bundles/SHARE123/join")
-            .exchange()
-            .expectStatus()
-            .isOk
-            .expectBody()
-            .jsonPath("$.shareCode")
-            .isEqualTo("SHARE123")
-    }
-
-    // endregion
-
     // region GET /api/v1/bundles/joined
 
     @Test
     fun `getJoinedBundles returns 200 with joined bundle metadata`() {
         val bundle = BackendFixtures.bundle()
         every { bundleService.getJoinedBundles(any(), any()) } returns Flux.just(bundle)
-        every { bundleService.prepareMetadata(bundle) } returns Mono.just(bundleMetadata())
+        every { bundleMapper.toMetadata(bundle) } returns Mono.just(bundleMetadata())
 
         authenticatedClient()
             .get()
@@ -181,7 +163,7 @@ class BundleControllerTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBodyList(BundleMetadata::class.java)
+            .expectBodyList<BundleMetadata>()
             .hasSize(1)
     }
 
@@ -266,7 +248,7 @@ class BundleControllerTest {
     @Test
     fun `replyToInvite accept returns 200 success message`() {
         val bundle = BackendFixtures.bundle()
-        every { bundleService.joinUser("SHARE123", "user-1") } returns Mono.just(bundle)
+        every { bundleService.reactToInvite("SHARE123", true, any()) } returns Mono.just(bundle)
 
         authenticatedClient()
             .post()
@@ -279,7 +261,7 @@ class BundleControllerTest {
     @Test
     fun `replyToInvite decline returns 200 success message`() {
         val bundle = BackendFixtures.bundle()
-        every { bundleService.declineInvite("SHARE123", any()) } returns Mono.just(bundle)
+        every { bundleService.reactToInvite("SHARE123", false, any()) } returns Mono.just(bundle)
 
         authenticatedClient()
             .post()
@@ -295,8 +277,9 @@ class BundleControllerTest {
 
     @Test
     fun `getUserRoles returns 200 with user role list`() {
-        every { bundleService.getBundleUsers("SHARE123", any()) } returns
-            Flux.just(UserNameWithRole("admin-1", UserRole.ADMIN))
+        val bundle = BackendFixtures.bundle(shareCode = "SHARE123")
+        every { bundleService.getBundleForModerator("SHARE123", any()) } returns Mono.just(bundle)
+        every { bundleMapper.toUserRoles(bundle) } returns Flux.just(UserNameWithRole("admin-1", UserRole.ADMIN))
 
         authenticatedClient()
             .get()
@@ -304,7 +287,7 @@ class BundleControllerTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBodyList(UserNameWithRole::class.java)
+            .expectBodyList<UserNameWithRole>()
             .hasSize(1)
     }
 
@@ -314,7 +297,9 @@ class BundleControllerTest {
 
     @Test
     fun `getInvitedUsers returns 200 with invited user list`() {
-        every { bundleService.getBundleInvitedUsers("SHARE123", any()) } returns Flux.just("invitee-1")
+        val bundle = BackendFixtures.bundle(shareCode = "SHARE123")
+        every { bundleService.getBundleForModerator("SHARE123", any()) } returns Mono.just(bundle)
+        every { bundleMapper.toInvitedUserNames(bundle) } returns Flux.just("invitee-1")
 
         authenticatedClient()
             .get()
@@ -322,7 +307,7 @@ class BundleControllerTest {
             .exchange()
             .expectStatus()
             .isOk
-            .expectBodyList(String::class.java)
+            .expectBodyList<String>()
             .hasSize(1)
     }
 
@@ -368,7 +353,7 @@ class BundleControllerTest {
     fun `changeVisibility returns 200 with updated bundle DTO`() {
         val bundle = BackendFixtures.bundle(isPublic = true)
         every { bundleService.changeVisibility("SHARE123", true, any()) } returns Mono.just(bundle)
-        every { bundleService.prepareDto(bundle, any()) } returns Mono.just(bundleDto())
+        every { bundleMapper.toDto(bundle, any()) } returns Mono.just(bundleDto())
 
         authenticatedClient()
             .post()
@@ -389,7 +374,7 @@ class BundleControllerTest {
     fun `changeProblems returns 200 with updated bundle DTO`() {
         val bundle = BackendFixtures.bundle(problemIds = listOf("1.0.0", "2.0.0"))
         every { bundleService.changeProblems("SHARE123", listOf("1.0.0", "2.0.0"), any()) } returns Mono.just(bundle)
-        every { bundleService.prepareDto(bundle, any()) } returns Mono.just(bundleDto())
+        every { bundleMapper.toDto(bundle, any()) } returns Mono.just(bundleDto())
 
         authenticatedClient()
             .post()

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemControllerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemControllerTest.kt
@@ -8,6 +8,7 @@ import io.github.sanyavertolet.edukate.backend.dtos.ProblemDto
 import io.github.sanyavertolet.edukate.backend.dtos.ProblemMetadata
 import io.github.sanyavertolet.edukate.backend.entities.Problem
 import io.github.sanyavertolet.edukate.backend.filters.ProblemFilter
+import io.github.sanyavertolet.edukate.backend.mappers.ProblemMapper
 import io.github.sanyavertolet.edukate.backend.services.ProblemService
 import io.github.sanyavertolet.edukate.common.security.NoopWebSecurityConfig
 import io.mockk.every
@@ -29,6 +30,7 @@ class ProblemControllerTest {
     @Autowired private lateinit var webTestClient: WebTestClient
 
     @MockkBean private lateinit var problemService: ProblemService
+    @MockkBean private lateinit var problemMapper: ProblemMapper
 
     private fun metadata(id: String = "1.0.0") = ProblemMetadata(id, false, emptyList(), Problem.Status.NOT_SOLVED)
 
@@ -41,7 +43,7 @@ class ProblemControllerTest {
     fun `getProblemList returns 200 with metadata list`() {
         every { problemService.getFilteredProblems(eq(ProblemFilter()), isNull(), any()) } returns
             Flux.just(BackendFixtures.problem("1.0.0"), BackendFixtures.problem("1.1.0"))
-        every { problemService.prepareMetadata(any(), isNull()) } returnsMany
+        every { problemMapper.toMetadata(any(), isNull()) } returnsMany
             listOf(Mono.just(metadata("1.0.0")), Mono.just(metadata("1.1.0")))
 
         webTestClient
@@ -60,7 +62,7 @@ class ProblemControllerTest {
     fun `getProblemList with prefix filter passes prefix to service`() {
         every { problemService.getFilteredProblems(eq(ProblemFilter(prefix = "1.")), isNull(), any()) } returns
             Flux.just(BackendFixtures.problem("1.0.0"), BackendFixtures.problem("1.1.0"))
-        every { problemService.prepareMetadata(any(), isNull()) } returnsMany
+        every { problemMapper.toMetadata(any(), isNull()) } returnsMany
             listOf(Mono.just(metadata("1.0.0")), Mono.just(metadata("1.1.0")))
 
         webTestClient
@@ -78,7 +80,7 @@ class ProblemControllerTest {
         every {
             problemService.getFilteredProblems(eq(ProblemFilter(status = Problem.Status.SOLVED)), isNull(), any())
         } returns Flux.just(BackendFixtures.problem("1.0.0"))
-        every { problemService.prepareMetadata(any(), isNull()) } returns Mono.just(metadata("1.0.0"))
+        every { problemMapper.toMetadata(any(), isNull()) } returns Mono.just(metadata("1.0.0"))
 
         webTestClient
             .get()
@@ -159,7 +161,7 @@ class ProblemControllerTest {
     fun `getProblem returns 200 when problem found`() {
         val problem = BackendFixtures.problem("1.0.0")
         every { problemService.findProblemById("1.0.0") } returns Mono.just(problem)
-        every { problemService.prepareDto(problem, isNull()) } returns Mono.just(dto("1.0.0"))
+        every { problemMapper.toDto(problem, isNull()) } returns Mono.just(dto("1.0.0"))
 
         webTestClient
             .get()

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/SubmissionControllerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/SubmissionControllerTest.kt
@@ -5,6 +5,7 @@ package io.github.sanyavertolet.edukate.backend.controllers
 import com.ninjasquad.springmockk.MockkBean
 import io.github.sanyavertolet.edukate.backend.BackendFixtures
 import io.github.sanyavertolet.edukate.backend.dtos.SubmissionDto
+import io.github.sanyavertolet.edukate.backend.mappers.SubmissionMapper
 import io.github.sanyavertolet.edukate.backend.services.ProblemService
 import io.github.sanyavertolet.edukate.backend.services.SubmissionService
 import io.github.sanyavertolet.edukate.backend.services.UserService
@@ -33,6 +34,7 @@ class SubmissionControllerTest {
     @MockkBean private lateinit var problemService: ProblemService
     @MockkBean private lateinit var userService: UserService
     @MockkBean private lateinit var submissionService: SubmissionService
+    @MockkBean private lateinit var submissionMapper: SubmissionMapper
     @MockkBean private lateinit var fileManager: FileManager
 
     private fun authenticatedClient(): WebTestClient =
@@ -58,7 +60,7 @@ class SubmissionControllerTest {
         val dto = submissionDto(id = "sub-1")
 
         every { submissionService.findById("sub-1") } returns Mono.just(submission)
-        every { submissionService.prepareDto(submission) } returns Mono.just(dto)
+        every { submissionMapper.toDto(submission) } returns Mono.just(dto)
 
         authenticatedClient()
             .get()
@@ -93,7 +95,7 @@ class SubmissionControllerTest {
 
         every { submissionService.findUserSubmissions(any(), isNull(), any()) } returns
             Flux.just(BackendFixtures.submission(id = "sub-1"), BackendFixtures.submission(id = "sub-2"))
-        every { submissionService.prepareDto(any()) } returnsMany listOf(Mono.just(dto1), Mono.just(dto2))
+        every { submissionMapper.toDto(any()) } returnsMany listOf(Mono.just(dto1), Mono.just(dto2))
 
         authenticatedClient()
             .get()

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapperTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapperTest.kt
@@ -1,0 +1,53 @@
+@file:Suppress("ReactiveStreamsUnusedPublisher")
+
+package io.github.sanyavertolet.edukate.backend.mappers
+
+import io.github.sanyavertolet.edukate.backend.BackendFixtures
+import io.github.sanyavertolet.edukate.backend.entities.Problem
+import io.github.sanyavertolet.edukate.backend.services.ProblemStatusDecisionManager
+import io.github.sanyavertolet.edukate.backend.services.files.FileManager
+import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class ProblemMapperTest {
+    private val problemStatusDecisionManager: ProblemStatusDecisionManager = mockk()
+    private val fileManager: FileManager = mockk()
+    private lateinit var mapper: ProblemMapper
+
+    @BeforeEach
+    fun setUp() {
+        mapper = ProblemMapper(problemStatusDecisionManager, fileManager)
+    }
+
+    @Test
+    fun `toDto zips status and images`() {
+        val auth = BackendFixtures.mockAuthentication()
+        val problem = BackendFixtures.problem(id = "1.0.0", images = listOf("img.png"))
+        every { problemStatusDecisionManager.getStatus("1.0.0", auth) } returns Mono.just(Problem.Status.SOLVED)
+        every { fileManager.getPresignedUrl(ProblemFileKey("1.0.0", "img.png")) } returns Mono.just("https://s3/img.png")
+
+        StepVerifier.create(mapper.toDto(problem, auth))
+            .assertNext { dto ->
+                assertThat(dto.status).isEqualTo(Problem.Status.SOLVED)
+                assertThat(dto.images).containsExactly("https://s3/img.png")
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `toMetadata applies status`() {
+        val auth = BackendFixtures.mockAuthentication()
+        val problem = BackendFixtures.problem(id = "1.0.0")
+        every { problemStatusDecisionManager.getStatus("1.0.0", auth) } returns Mono.just(Problem.Status.SOLVING)
+
+        StepVerifier.create(mapper.toMetadata(problem, auth))
+            .assertNext { meta -> assertThat(meta.status).isEqualTo(Problem.Status.SOLVING) }
+            .verifyComplete()
+    }
+}

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/mappers/SubmissionMapperTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/mappers/SubmissionMapperTest.kt
@@ -1,0 +1,90 @@
+@file:Suppress("ReactiveStreamsUnusedPublisher")
+
+package io.github.sanyavertolet.edukate.backend.mappers
+
+import io.github.sanyavertolet.edukate.backend.BackendFixtures
+import io.github.sanyavertolet.edukate.backend.entities.files.FileObject
+import io.github.sanyavertolet.edukate.backend.entities.files.FileObjectMetadata
+import io.github.sanyavertolet.edukate.backend.repositories.FileObjectRepository
+import io.github.sanyavertolet.edukate.backend.services.ProblemService
+import io.github.sanyavertolet.edukate.backend.services.UserService
+import io.github.sanyavertolet.edukate.backend.services.files.FileManager
+import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
+import io.github.sanyavertolet.edukate.storage.keys.SubmissionFileKey
+import io.mockk.every
+import io.mockk.mockk
+import java.time.Instant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class SubmissionMapperTest {
+    private val fileObjectRepository: FileObjectRepository = mockk()
+    private val fileManager: FileManager = mockk()
+    private val userService: UserService = mockk()
+    private val problemService: ProblemService = mockk()
+    private lateinit var mapper: SubmissionMapper
+
+    @BeforeEach
+    fun setUp() {
+        mapper = SubmissionMapper(fileObjectRepository, fileManager, userService, problemService)
+    }
+
+    @Test
+    fun `toDto collects file urls and user name`() {
+        val fileKey = SubmissionFileKey("user-1", "1.0.0", "sub-1", "solution.txt")
+        val fileObject =
+            FileObject(
+                id = "fo-1",
+                keyPath = fileKey.toString(),
+                key = fileKey,
+                type = "submission",
+                ownerUserId = "user-1",
+                metadata = FileObjectMetadata(Instant.now(), 100L, "text/plain"),
+            )
+        val submission = BackendFixtures.submission(id = "sub-1", userId = "user-1", fileObjectIds = listOf("fo-1"))
+
+        every { fileObjectRepository.findAllById(listOf("fo-1")) } returns Flux.just(fileObject)
+        every { fileManager.getPresignedUrl(fileKey) } returns Mono.just("https://s3/solution.txt")
+        every { userService.findUserById("user-1") } returns Mono.just(BackendFixtures.user(id = "user-1", name = "alice"))
+
+        StepVerifier.create(mapper.toDto(submission))
+            .assertNext { dto ->
+                assertThat(dto.userName).isEqualTo("alice")
+                assertThat(dto.fileUrls).containsExactly("https://s3/solution.txt")
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `prepareContext builds SubmissionContext`() {
+        val problem = BackendFixtures.problem(id = "1.0.0", text = "Solve it", images = listOf("img.png"))
+        val fileKey = SubmissionFileKey("user-1", "1.0.0", "sub-1", "solution.txt")
+        val fileObject =
+            FileObject(
+                id = "fo-1",
+                keyPath = fileKey.toString(),
+                key = fileKey,
+                type = "submission",
+                ownerUserId = "user-1",
+                metadata = FileObjectMetadata(Instant.now(), 100L, "text/plain"),
+            )
+        val submission = BackendFixtures.submission(id = "sub-1", userId = "user-1", fileObjectIds = listOf("fo-1"))
+
+        every { problemService.findProblemById("1.0.0") } returns Mono.just(problem)
+        every { fileObjectRepository.findAllById(listOf("fo-1")) } returns Flux.just(fileObject)
+
+        StepVerifier.create(mapper.prepareContext(submission))
+            .assertNext { ctx ->
+                assertThat(ctx.submissionId).isEqualTo("sub-1")
+                assertThat(ctx.problemId).isEqualTo("1.0.0")
+                assertThat(ctx.problemText).isEqualTo("Solve it")
+                assertThat(ctx.problemImageRawKeys).containsExactly(ProblemFileKey("1.0.0", "img.png").toString())
+                assertThat(ctx.submissionImageRawKeys).containsExactly(fileKey.toString())
+            }
+            .verifyComplete()
+    }
+}

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/BundleServiceTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/BundleServiceTest.kt
@@ -8,7 +8,6 @@ import io.github.sanyavertolet.edukate.backend.repositories.BundleRepository
 import io.github.sanyavertolet.edukate.common.users.UserRole
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.verify
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
@@ -21,14 +20,12 @@ class BundleServiceTest {
 
     private val bundleRepository: BundleRepository = mockk()
     private val shareCodeGenerator: ShareCodeGenerator = mockk()
-    private val problemService: ProblemService = mockk()
     private val bundlePermissionEvaluator: BundlePermissionEvaluator = mockk()
-    private val userService: UserService = mockk()
     private lateinit var service: BundleService
 
     @BeforeEach
     fun setUp() {
-        service = BundleService(bundleRepository, shareCodeGenerator, problemService, bundlePermissionEvaluator, userService)
+        service = BundleService(bundleRepository, shareCodeGenerator, bundlePermissionEvaluator)
     }
 
     // region findBundleByShareCode
@@ -105,49 +102,6 @@ class BundleServiceTest {
                 assert(saved.shareCode == "NEWCODE")
             }
             .verifyComplete()
-    }
-
-    // endregion
-
-    // region joinUser
-
-    @Test
-    fun `joinUser adds user to bundle when allowed`() {
-        val bundle = BackendFixtures.bundle(isPublic = true, shareCode = "JOIN1")
-        every { bundleRepository.findBundleByShareCode("JOIN1") } returns Mono.just(bundle)
-        every { bundlePermissionEvaluator.hasJoinPermission(bundle, "new-user") } returns true
-        every { bundleRepository.save(any()) } answers { Mono.just(firstArg()) }
-
-        StepVerifier.create(service.joinUser("JOIN1", "new-user"))
-            .assertNext { updated -> assert(updated.isUserInBundle("new-user")) }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `joinUser emits FORBIDDEN when user has no join permission`() {
-        val bundle = BackendFixtures.bundle(isPublic = false, invitedUserIds = emptySet(), shareCode = "JOIN2")
-        every { bundleRepository.findBundleByShareCode("JOIN2") } returns Mono.just(bundle)
-        every { bundlePermissionEvaluator.hasJoinPermission(bundle, "stranger") } returns false
-
-        StepVerifier.create(service.joinUser("JOIN2", "stranger"))
-            .expectErrorMatches { it is ResponseStatusException && it.statusCode == HttpStatus.FORBIDDEN }
-            .verify()
-    }
-
-    @Test
-    fun `joinUser emits BAD_REQUEST when user is already in bundle`() {
-        val bundle =
-            BackendFixtures.bundle(
-                isPublic = true,
-                userIdRoleMap = mapOf("admin-1" to UserRole.ADMIN, "user-1" to UserRole.USER),
-                shareCode = "JOIN3",
-            )
-        every { bundleRepository.findBundleByShareCode("JOIN3") } returns Mono.just(bundle)
-        every { bundlePermissionEvaluator.hasJoinPermission(bundle, "user-1") } returns true
-
-        StepVerifier.create(service.joinUser("JOIN3", "user-1"))
-            .expectErrorMatches { it is ResponseStatusException && it.statusCode == HttpStatus.BAD_REQUEST }
-            .verify()
     }
 
     // endregion
@@ -272,17 +226,6 @@ class BundleServiceTest {
     // endregion
 
     // region changeProblems
-
-    @Test
-    fun `changeProblems emits BAD_REQUEST when problem list is empty`() {
-        val auth = BackendFixtures.mockAuthentication()
-
-        StepVerifier.create(service.changeProblems("PROB1", emptyList(), auth))
-            .expectErrorMatches { it is ResponseStatusException && it.statusCode == HttpStatus.BAD_REQUEST }
-            .verify()
-
-        verify(exactly = 0) { bundleRepository.findBundleByShareCode(any()) }
-    }
 
     @Test
     fun `changeProblems updates problemIds when authorized`() {

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/ProblemServiceTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/ProblemServiceTest.kt
@@ -6,12 +6,9 @@ import io.github.sanyavertolet.edukate.backend.BackendFixtures
 import io.github.sanyavertolet.edukate.backend.entities.Problem
 import io.github.sanyavertolet.edukate.backend.filters.ProblemFilter
 import io.github.sanyavertolet.edukate.backend.repositories.ProblemRepository
-import io.github.sanyavertolet.edukate.backend.services.files.FileManager
-import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.data.domain.PageRequest
@@ -24,13 +21,11 @@ import reactor.test.StepVerifier
 class ProblemServiceTest {
     private val problemRepository: ProblemRepository = mockk()
     private val mongoTemplate: ReactiveMongoTemplate = mockk()
-    private val fileManager: FileManager = mockk()
-    private val problemStatusDecisionManager: ProblemStatusDecisionManager = mockk()
     private lateinit var service: ProblemService
 
     @BeforeEach
     fun setUp() {
-        service = ProblemService(problemRepository, mongoTemplate, fileManager, problemStatusDecisionManager)
+        service = ProblemService(problemRepository, mongoTemplate)
     }
 
     // region getFilteredProblems
@@ -146,42 +141,4 @@ class ProblemServiceTest {
 
     // endregion
 
-    // region problemImageDownloadUrls / prepareDto / prepareMetadata
-
-    @Test
-    fun `problemImageDownloadUrls generates presigned urls`() {
-        every { fileManager.getPresignedUrl(ProblemFileKey("1.0.0", "img.png")) } returns Mono.just("https://s3/img.png")
-
-        StepVerifier.create(service.problemImageDownloadUrls("1.0.0", listOf("img.png")))
-            .expectNext("https://s3/img.png")
-            .verifyComplete()
-    }
-
-    @Test
-    fun `prepareDto zips status and images`() {
-        val auth = BackendFixtures.mockAuthentication()
-        val problem = BackendFixtures.problem(id = "1.0.0", images = listOf("img.png"))
-        every { problemStatusDecisionManager.getStatus("1.0.0", auth) } returns Mono.just(Problem.Status.SOLVED)
-        every { fileManager.getPresignedUrl(ProblemFileKey("1.0.0", "img.png")) } returns Mono.just("https://s3/img.png")
-
-        StepVerifier.create(service.prepareDto(problem, auth))
-            .assertNext { dto ->
-                assertThat(dto.status).isEqualTo(Problem.Status.SOLVED)
-                assertThat(dto.images).containsExactly("https://s3/img.png")
-            }
-            .verifyComplete()
-    }
-
-    @Test
-    fun `prepareMetadata applies status`() {
-        val auth = BackendFixtures.mockAuthentication()
-        val problem = BackendFixtures.problem(id = "1.0.0")
-        every { problemStatusDecisionManager.getStatus("1.0.0", auth) } returns Mono.just(Problem.Status.SOLVING)
-
-        StepVerifier.create(service.prepareMetadata(problem, auth))
-            .assertNext { meta -> assertThat(meta.status).isEqualTo(Problem.Status.SOLVING) }
-            .verifyComplete()
-    }
-
-    // endregion
 }

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/SubmissionServiceTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/SubmissionServiceTest.kt
@@ -8,10 +8,8 @@ import io.github.sanyavertolet.edukate.backend.entities.files.FileObjectMetadata
 import io.github.sanyavertolet.edukate.backend.permissions.SubmissionPermissionEvaluator
 import io.github.sanyavertolet.edukate.backend.repositories.FileObjectRepository
 import io.github.sanyavertolet.edukate.backend.repositories.SubmissionRepository
-import io.github.sanyavertolet.edukate.backend.services.files.FileManager
 import io.github.sanyavertolet.edukate.backend.services.files.SubmissionFileService
 import io.github.sanyavertolet.edukate.common.SubmissionStatus
-import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
 import io.github.sanyavertolet.edukate.storage.keys.SubmissionFileKey
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import io.mockk.every
@@ -30,11 +28,8 @@ import reactor.test.StepVerifier
 
 class SubmissionServiceTest {
     private val submissionRepository: SubmissionRepository = mockk()
-    private val fileManager: FileManager = mockk()
     private val submissionFileService: SubmissionFileService = mockk()
-    private val userService: UserService = mockk()
     private val fileObjectRepository: FileObjectRepository = mockk()
-    private val problemService: ProblemService = mockk()
     private val submissionPermissionEvaluator: SubmissionPermissionEvaluator = mockk()
     private val meterRegistry = SimpleMeterRegistry()
     private lateinit var service: SubmissionService
@@ -44,11 +39,8 @@ class SubmissionServiceTest {
         service =
             SubmissionService(
                 submissionRepository,
-                fileManager,
                 submissionFileService,
-                userService,
                 fileObjectRepository,
-                problemService,
                 submissionPermissionEvaluator,
                 meterRegistry,
             )
@@ -194,66 +186,4 @@ class SubmissionServiceTest {
 
     // endregion
 
-    // region prepareDto
-
-    @Test
-    fun `prepareDto collects file urls and user name`() {
-        val fileKey = SubmissionFileKey("user-1", "1.0.0", "sub-1", "solution.txt")
-        val fileObject =
-            FileObject(
-                id = "fo-1",
-                keyPath = fileKey.toString(),
-                key = fileKey,
-                type = "submission",
-                ownerUserId = "user-1",
-                metadata = FileObjectMetadata(Instant.now(), 100L, "text/plain"),
-            )
-        val submission = BackendFixtures.submission(id = "sub-1", userId = "user-1", fileObjectIds = listOf("fo-1"))
-
-        every { fileObjectRepository.findAllById(listOf("fo-1")) } returns Flux.just(fileObject)
-        every { fileManager.getPresignedUrl(fileKey) } returns Mono.just("https://s3/solution.txt")
-        every { userService.findUserName("user-1") } returns Mono.just("alice")
-
-        StepVerifier.create(service.prepareDto(submission))
-            .assertNext { dto ->
-                assertThat(dto.userName).isEqualTo("alice")
-                assertThat(dto.fileUrls).containsExactly("https://s3/solution.txt")
-            }
-            .verifyComplete()
-    }
-
-    // endregion
-
-    // region prepareContext
-
-    @Test
-    fun `prepareContext builds SubmissionContext`() {
-        val problem = BackendFixtures.problem(id = "1.0.0", text = "Solve it", images = listOf("img.png"))
-        val fileKey = SubmissionFileKey("user-1", "1.0.0", "sub-1", "solution.txt")
-        val fileObject =
-            FileObject(
-                id = "fo-1",
-                keyPath = fileKey.toString(),
-                key = fileKey,
-                type = "submission",
-                ownerUserId = "user-1",
-                metadata = FileObjectMetadata(Instant.now(), 100L, "text/plain"),
-            )
-        val submission = BackendFixtures.submission(id = "sub-1", userId = "user-1", fileObjectIds = listOf("fo-1"))
-
-        every { problemService.findProblemById("1.0.0") } returns Mono.just(problem)
-        every { fileManager.getFileObjectsByIds(listOf("fo-1")) } returns Flux.just(fileObject)
-
-        StepVerifier.create(service.prepareContext(submission))
-            .assertNext { ctx ->
-                assertThat(ctx.submissionId).isEqualTo("sub-1")
-                assertThat(ctx.problemId).isEqualTo("1.0.0")
-                assertThat(ctx.problemText).isEqualTo("Solve it")
-                assertThat(ctx.problemImageRawKeys).containsExactly(ProblemFileKey("1.0.0", "img.png").toString())
-                assertThat(ctx.submissionImageRawKeys).containsExactly(fileKey.toString())
-            }
-            .verifyComplete()
-    }
-
-    // endregion
 }

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/UserServiceTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/UserServiceTest.kt
@@ -27,19 +27,6 @@ class UserServiceTest {
         service = UserService(userRepository, notifier)
     }
 
-    // region findUserByAuthentication
-
-    @Test
-    fun `findUserByAuthentication returns User`() {
-        val user = BackendFixtures.user(id = "user-1")
-        val auth = BackendFixtures.mockAuthentication(userId = "user-1")
-        every { userRepository.findById("user-1") } returns Mono.just(user)
-
-        StepVerifier.create(service.findUserByAuthentication(auth)).expectNext(user).verifyComplete()
-    }
-
-    // endregion
-
     // region findUserByName
 
     @Test
@@ -55,25 +42,6 @@ class UserServiceTest {
         every { userRepository.findByName("ghost") } returns Mono.empty()
 
         StepVerifier.create(service.findUserByName("ghost")).verifyComplete()
-    }
-
-    // endregion
-
-    // region findUserName
-
-    @Test
-    fun `findUserName returns name`() {
-        val user = BackendFixtures.user(id = "user-1", name = "alice")
-        every { userRepository.findById("user-1") } returns Mono.just(user)
-
-        StepVerifier.create(service.findUserName("user-1")).expectNext("alice").verifyComplete()
-    }
-
-    @Test
-    fun `findUserName returns unknown for missing User`() {
-        every { userRepository.findById("nobody") } returns Mono.empty()
-
-        StepVerifier.create(service.findUserName("nobody")).expectNext("UNKNOWN").verifyComplete()
     }
 
     // endregion

--- a/edukate-common/src/main/kotlin/io/github/sanyavertolet/edukate/common/users/UserCredentials.kt
+++ b/edukate-common/src/main/kotlin/io/github/sanyavertolet/edukate/common/users/UserCredentials.kt
@@ -4,7 +4,7 @@ data class UserCredentials(
     val id: String?,
     val username: String,
     val encodedPassword: String,
-    val email: String,
+    val email: String? = null,
     val roles: Set<UserRole>,
     val status: UserStatus,
 ) {

--- a/edukate-common/src/main/kotlin/io/github/sanyavertolet/edukate/common/utils/ReactorUtils.kt
+++ b/edukate-common/src/main/kotlin/io/github/sanyavertolet/edukate/common/utils/ReactorUtils.kt
@@ -1,0 +1,31 @@
+package io.github.sanyavertolet.edukate.common.utils
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.server.ResponseStatusException
+import reactor.core.publisher.Mono
+
+// --- base ---
+
+fun <T : Any> Mono<T>.orThrow(status: HttpStatus, message: String): Mono<T> =
+    switchIfEmpty(Mono.error(ResponseStatusException(status, message)))
+
+/** Throws [status] error if [condition] is TRUE (i.e. the condition describes the failure case). */
+fun <T : Any> Mono<T>.throwIf(status: HttpStatus, message: String, condition: (T) -> Boolean): Mono<T> =
+    filter { !condition(it) }.orThrow(status, message)
+
+// --- semantic aliases for common HTTP statuses ---
+
+fun <T : Any> Mono<T>.orNotFound(message: String): Mono<T> = orThrow(HttpStatus.NOT_FOUND, message)
+
+fun <T : Any> Mono<T>.orForbidden(message: String): Mono<T> = orThrow(HttpStatus.FORBIDDEN, message)
+
+fun <T : Any> Mono<T>.orBadRequest(message: String): Mono<T> = orThrow(HttpStatus.BAD_REQUEST, message)
+
+fun <T : Any> Mono<T>.notFoundIf(message: String, condition: (T) -> Boolean): Mono<T> =
+    throwIf(HttpStatus.NOT_FOUND, message, condition)
+
+fun <T : Any> Mono<T>.forbiddenIf(message: String, condition: (T) -> Boolean): Mono<T> =
+    throwIf(HttpStatus.FORBIDDEN, message, condition)
+
+fun <T : Any> Mono<T>.badRequestIf(message: String, condition: (T) -> Boolean): Mono<T> =
+    throwIf(HttpStatus.BAD_REQUEST, message, condition)

--- a/edukate-frontend/src/features/bundles/api.ts
+++ b/edukate-frontend/src/features/bundles/api.ts
@@ -11,7 +11,6 @@ import {
     getPublicBundles,
     getUserRoles,
     inviteToBundle,
-    joinBundle,
     replyToInvite,
 } from "@/generated/backend";
 import { useAuthContext } from "@/features/auth/context";
@@ -53,16 +52,6 @@ export function useBundlesRequest(category: BundleCategory) {
     return useQuery({
         queryKey: queryKeys.bundles.list(category),
         queryFn: ({ signal }) => bundleListFn[category](undefined, signal),
-    });
-}
-
-export function useJoinBundleMutation() {
-    return useMutation({
-        mutationFn: (shareCode: string) => joinBundle(shareCode),
-        onSuccess: (_data, shareCode) => {
-            void queryClient.invalidateQueries({ queryKey: queryKeys.bundles.list("joined") });
-            void queryClient.invalidateQueries({ queryKey: queryKeys.bundles.detail(shareCode) });
-        },
     });
 }
 

--- a/edukate-frontend/src/features/bundles/components/BundleJoinForm.tsx
+++ b/edukate-frontend/src/features/bundles/components/BundleJoinForm.tsx
@@ -1,12 +1,10 @@
 import { Divider, IconButton, InputBase, Paper, Tooltip } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import GroupOutlinedIcon from "@mui/icons-material/GroupOutlined";
-import { FC, useState } from "react";
+import { FC } from "react";
 import { useNavigate } from "react-router-dom";
-import { useJoinBundleMutation } from "@/features/bundles/api";
 import { defaultTooltipSlotProps } from "@/shared/utils/utils";
 import { ConditionalTooltip } from "@/shared/components/ConditionalTooltip";
-import { toast } from "react-toastify";
 
 interface BundleJoinFormProps {
     disabled?: boolean;
@@ -14,45 +12,26 @@ interface BundleJoinFormProps {
 
 export const BundleJoinForm: FC<BundleJoinFormProps> = ({ disabled = false }) => {
     const navigate = useNavigate();
-    const joinBundleMutation = useJoinBundleMutation();
-    const [bundleCode, setBundleCode] = useState("");
 
-    const requestOptions = {
-        onSuccess: () => navigate(`/bundles/${bundleCode}`),
-        onError: () => {
-            joinBundleMutation.reset();
-            setBundleCode("");
-            toast.error("Could not join a bundle");
-        },
-    };
-
-    const onSearchClick = () => {
-        joinBundleMutation.mutate(bundleCode, requestOptions);
-    };
     const onCreateClick = () => {
         void navigate("/bundles/new");
     };
     return (
         <ConditionalTooltip title={"Sign in to use bundles"} shown={disabled} placement={"bottom-end"}>
             <Paper component="form" sx={{ p: "0px 1px", display: "flex", alignItems: "center" }}>
-                <InputBase
-                    sx={{ ml: 1, flex: 1 }}
-                    placeholder="Join by code"
-                    inputProps={{ "aria-label": "join by code" }}
-                    value={bundleCode}
-                    disabled={disabled}
-                    onChange={(e) => {
-                        setBundleCode(e.target.value);
-                    }}
-                />
-                <IconButton
-                    color="default"
-                    aria-label="join"
-                    onClick={onSearchClick}
-                    disabled={disabled || bundleCode.length == 0}
-                >
-                    <GroupOutlinedIcon />
-                </IconButton>
+                <Tooltip title="Join by invite link — coming soon" slotProps={defaultTooltipSlotProps}>
+                    <span>
+                        <InputBase
+                            sx={{ ml: 1, flex: 1 }}
+                            placeholder="Join by code"
+                            inputProps={{ "aria-label": "join by code" }}
+                            disabled
+                        />
+                        <IconButton color="default" aria-label="join" disabled>
+                            <GroupOutlinedIcon />
+                        </IconButton>
+                    </span>
+                </Tooltip>
                 <Divider sx={{ height: "1.75rem" }} orientation="vertical" />
                 <IconButton color="secondary" aria-label="create" onClick={onCreateClick} disabled={disabled}>
                     <Tooltip title="Create a bundle" slotProps={defaultTooltipSlotProps}>

--- a/edukate-gateway/build.gradle.kts
+++ b/edukate-gateway/build.gradle.kts
@@ -42,6 +42,8 @@ dependencies {
     implementation(libs.spring.boot.starter.opentelemetry)
     implementation(libs.logstash.logback.encoder)
     implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.cache)
+    implementation(libs.caffeine)
     implementation(libs.spring.cloud.starter.gateway.server.webflux)
     implementation(libs.springdoc.openapi.starter.webflux.ui)
     implementation(libs.jackson.module.kotlin)

--- a/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/configs/CacheConfig.kt
+++ b/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/configs/CacheConfig.kt
@@ -1,0 +1,23 @@
+package io.github.sanyavertolet.edukate.gateway.configs
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.cache.caffeine.CaffeineCacheManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableCaching
+class CacheConfig {
+    @Bean
+    fun cacheManager(): CacheManager {
+        val manager = CaffeineCacheManager()
+        manager.setAsyncCacheMode(true)
+        manager.registerCustomCache(
+            "user-credentials-by-id",
+            Caffeine.from("maximumSize=500,expireAfterWrite=24h").buildAsync(),
+        )
+        return manager
+    }
+}

--- a/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/AuthService.kt
+++ b/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/AuthService.kt
@@ -20,7 +20,7 @@ class AuthService(
         userDetailsService
             .findEdukateUserDetailsByUsername(signInRequest.username)
             .filter { passwordEncoder.matches(signInRequest.password, it.password) }
-            .map { userDetails -> jwtTokenService.generateToken(userDetails) }
+            .map { jwtTokenService.generateToken(it) }
 
     fun signUp(signUpRequest: SignUpRequest): Mono<String> =
         signUpRequest
@@ -28,5 +28,5 @@ class AuthService(
             .filterWhen { userDetailsService.isNotUserPresent(it.username) }
             .switchIfEmpty(Mono.error(ResponseStatusException(HttpStatus.CONFLICT)))
             .flatMap { userDetailsService.create(it.username, it.email, checkNotNull(passwordEncoder.encode(it.password))) }
-            .map { userDetails -> jwtTokenService.generateToken(userDetails) }
+            .map { jwtTokenService.generateToken(it) }
 }

--- a/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/BackendService.kt
+++ b/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/BackendService.kt
@@ -2,6 +2,7 @@ package io.github.sanyavertolet.edukate.gateway.services
 
 import io.github.sanyavertolet.edukate.common.users.UserCredentials
 import io.github.sanyavertolet.edukate.gateway.configs.GatewayProperties
+import org.springframework.cache.annotation.Cacheable
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
@@ -22,10 +23,13 @@ class BackendService(gatewayProperties: GatewayProperties, webClientBuilder: Web
             Mono.empty()
         }
 
+    @Cacheable(cacheNames = ["user-credentials-by-id"], key = "#id")
     fun getUserById(id: String): Mono<UserCredentials> =
-        webClient.get().uri("/internal/users/by-id/{id}", id).retrieve().bodyToMono<UserCredentials>().onErrorResume(
-            WebClientResponseException.NotFound::class.java
-        ) {
-            Mono.empty()
-        }
+        webClient
+            .get()
+            .uri("/internal/users/by-id/{id}", id)
+            .retrieve()
+            .bodyToMono<UserCredentials>()
+            .map { it.copy(encodedPassword = "") }
+            .onErrorResume(WebClientResponseException.NotFound::class.java) { Mono.empty() }
 }

--- a/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/UserDetailsService.kt
+++ b/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/UserDetailsService.kt
@@ -11,16 +11,20 @@ import reactor.core.publisher.Mono
 @Service
 class UserDetailsService(private val backendService: BackendService) :
     ReactiveUserDetailsService, ReactiveUserDetailsPasswordService {
-    override fun findByUsername(username: String): Mono<UserDetails> = findEdukateUserDetailsByUsername(username).map { it }
 
-    override fun updatePassword(user: UserDetails, newPassword: String?): Mono<UserDetails> = Mono.just(user)
+    override fun findByUsername(username: String): Mono<UserDetails> =
+        backendService.getUserByName(username).map(::EdukateUserDetails)
 
     fun findEdukateUserDetailsByUsername(username: String): Mono<EdukateUserDetails> =
         backendService.getUserByName(username).map(::EdukateUserDetails)
 
     fun findById(id: String): Mono<EdukateUserDetails> = backendService.getUserById(id).map(::EdukateUserDetails)
 
-    fun isNotUserPresent(username: String): Mono<Boolean> = findByUsername(username).hasElement().map { !it }
+    fun isNotUserPresent(username: String): Mono<Boolean> =
+        backendService.getUserByName(username).map { false }.defaultIfEmpty(true)
+
+    // todo: looks like this dummy stub needs to be fixed
+    override fun updatePassword(user: UserDetails, newPassword: String?): Mono<UserDetails> = Mono.just(user)
 
     fun create(username: String, email: String, encodedPassword: String): Mono<EdukateUserDetails> {
         val userCredentials = UserCredentials.newUser(username, encodedPassword, email)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-
 spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
 spring-boot-starter-amqp = { module = "org.springframework.boot:spring-boot-starter-amqp" }
 spring-boot-starter-aspectj = { module = "org.springframework.boot:spring-boot-starter-aspectj" }
+spring-boot-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache" }
+caffeine = { module = "com.github.ben-manes.caffeine:caffeine" }
 spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
 spring-boot-starter = { module = "org.springframework.boot:spring-boot-starter" }
 spring-boot-starter-data-mongodb-reactive = { module = "org.springframework.boot:spring-boot-starter-data-mongodb-reactive" }

--- a/spec/openapi-edukate-backend.yaml
+++ b/spec/openapi-edukate-backend.yaml
@@ -503,54 +503,6 @@ paths:
                 type: string
       security:
       - cookieAuth: []
-  /api/v1/bundles/{shareCode}/join:
-    post:
-      tags:
-      - Bundles
-      summary: Join a bundle
-      description: Joins a bundle using its share code
-      operationId: joinBundle
-      parameters:
-      - name: shareCode
-        in: path
-        description: Bundle share code
-        required: true
-        schema:
-          type: string
-          minLength: 1
-      responses:
-        "200":
-          description: Successfully joined bundle
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BundleMetadata"
-        "400":
-          description: Already in bundle
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BundleMetadata"
-        "401":
-          description: Unauthorized
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BundleMetadata"
-        "403":
-          description: Access denied - invite is required to join
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BundleMetadata"
-        "404":
-          description: Bundle not found
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/BundleMetadata"
-      security:
-      - cookieAuth: []
   /api/v1/bundles/{shareCode}/invite:
     post:
       tags:
@@ -1652,31 +1604,6 @@ components:
           minItems: 1
       required:
       - problemIds
-    BundleMetadata:
-      type: object
-      properties:
-        name:
-          type: string
-        description:
-          type: string
-        admins:
-          type: array
-          items:
-            type: string
-        shareCode:
-          type: string
-        isPublic:
-          type: boolean
-        size:
-          type: integer
-          format: int64
-      required:
-      - admins
-      - description
-      - isPublic
-      - name
-      - shareCode
-      - size
     UserDto:
       type: object
       properties:
@@ -1846,6 +1773,31 @@ components:
       required:
       - name
       - role
+    BundleMetadata:
+      type: object
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        admins:
+          type: array
+          items:
+            type: string
+        shareCode:
+          type: string
+        isPublic:
+          type: boolean
+        size:
+          type: integer
+          format: int64
+      required:
+      - admins
+      - description
+      - isPublic
+      - name
+      - shareCode
+      - size
   securitySchemes:
     cookieAuth:
       type: apiKey


### PR DESCRIPTION
### What's done:
 * Removed `/api/v1/bundles/{shareCode}/join` endpoint from OpenAPI spec and backend services.
 * Deleted `BundleJoinForm` UI for joining bundles by share code in the frontend.
 * Updated domain documentation to reflect removal of open joining.
 * Refactored related mutation and API code to remove the joinBundle logic.
 * Introduced placeholders and tooltips for future invite-link functionality.
 * Improved caching by adding configurations to handle bundle data effectively.