### PR TITLE
Remove unused dependency from `build.gradle.kts`

### DIFF
--- a/edukate-checker/build.gradle.kts
+++ b/edukate-checker/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(libs.spring.boot.starter.amqp)
     implementation(libs.spring.ai.starter.model.openai)
     implementation(libs.spring.boot.http.client)
-    runtimeOnly(libs.spring.boot.autoconfigure.classic)
     implementation(libs.kotlin.reflect)
 
     developmentOnly(libs.spring.boot.devtools)


### PR DESCRIPTION
### What's done:
 * Deleted `spring.boot.autoconfigure.classic` as it is no longer required.