### PR TITLE
Update caching, client configuration, and Prometheus access

### DIFF
--- a/edukate-backend/src/main/resources/application-dev.properties
+++ b/edukate-backend/src/main/resources/application-dev.properties
@@ -1,4 +1,5 @@
 spring.docker.compose.enabled=false
+spring.web.error.include-message=always
 
 spring.r2dbc.url=r2dbc:postgresql://admin:secret@localhost:5432/edukate
 spring.flyway.url=jdbc:postgresql://localhost:5432/edukate

--- a/edukate-backend/src/main/resources/application.properties
+++ b/edukate-backend/src/main/resources/application.properties
@@ -11,10 +11,9 @@ springdoc.swagger-ui.enabled=false
 
 management.server.port=5801
 management.endpoints.web.exposure.include=health,info,loggers,prometheus
-management.endpoint.prometheus.access=unrestricted
+management.endpoint.prometheus.access=read_only
 management.metrics.tags.application=${spring.application.name}
 logging.group.edukate=io.github.sanyavertolet
-spring.web.error.include-message=always
 
 s3.region=${S3_REGION}
 s3.access-key=${S3_ACCESS_KEY}

--- a/edukate-checker/src/main/resources/application-dev.properties
+++ b/edukate-checker/src/main/resources/application-dev.properties
@@ -1,4 +1,5 @@
 spring.docker.compose.enabled=false
+spring.web.error.include-message=always
 
 checker.openai.system-prompt=Instruction to model: \
 You are a physics problem-solving and verification expert. You will be provided with:\
@@ -32,4 +33,4 @@ spring.rabbitmq.addresses=amqp://guest:guest@localhost:5672
 
 gateway.url=http://localhost:5810
 
-management.tracing.enabled=false
+management.tracing.export.enabled=false

--- a/edukate-checker/src/main/resources/application.properties
+++ b/edukate-checker/src/main/resources/application.properties
@@ -4,10 +4,9 @@ server.port=5830
 
 management.server.port=5831
 management.endpoints.web.exposure.include=health,info,loggers,prometheus
-management.endpoint.prometheus.access=unrestricted
+management.endpoint.prometheus.access=read_only
 management.metrics.tags.application=${spring.application.name}
 logging.group.edukate=io.github.sanyavertolet
-spring.web.error.include-message=always
 
 checker.openai.system-prompt=${OPENAI_SYSTEM_PROMPT}
 spring.ai.openai.api-key=${OPENAI_API_KEY}

--- a/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/configs/CacheConfig.kt
+++ b/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/configs/CacheConfig.kt
@@ -16,7 +16,7 @@ class CacheConfig {
         manager.setAsyncCacheMode(true)
         manager.registerCustomCache(
             "user-credentials-by-id",
-            Caffeine.from("maximumSize=500,expireAfterWrite=24h").recordStats().buildAsync(),
+            Caffeine.from("maximumSize=500,expireAfterWrite=5m").recordStats().buildAsync(),
         )
         return manager
     }

--- a/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/BackendService.kt
+++ b/edukate-gateway/src/main/kotlin/io/github/sanyavertolet/edukate/gateway/services/BackendService.kt
@@ -3,11 +3,15 @@ package io.github.sanyavertolet.edukate.gateway.services
 import io.github.sanyavertolet.edukate.common.users.UserCredentials
 import io.github.sanyavertolet.edukate.gateway.configs.GatewayProperties
 import io.github.sanyavertolet.edukate.gateway.repositories.GatewayUserRepository
+import io.netty.channel.ChannelOption
+import java.time.Duration
 import org.springframework.cache.annotation.Cacheable
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import reactor.netty.http.client.HttpClient
 
 @Service
 class BackendService(
@@ -15,7 +19,17 @@ class BackendService(
     webClientBuilder: WebClient.Builder,
     private val gatewayUserRepository: GatewayUserRepository,
 ) {
-    private val webClient: WebClient = webClientBuilder.baseUrl(gatewayProperties.backend.url).build()
+    private val webClient: WebClient =
+        webClientBuilder
+            .baseUrl(gatewayProperties.backend.url)
+            .clientConnector(
+                ReactorClientHttpConnector(
+                    HttpClient.create()
+                        .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT_MS)
+                        .responseTimeout(Duration.ofSeconds(RESPONSE_TIMEOUT_SECONDS))
+                )
+            )
+            .build()
 
     fun saveUser(userCredentials: UserCredentials): Mono<UserCredentials> =
         webClient.post().uri("/internal/users").bodyValue(userCredentials).retrieve().bodyToMono<UserCredentials>()
@@ -26,4 +40,9 @@ class BackendService(
     @Cacheable(cacheNames = ["user-credentials-by-id"], key = "#id")
     fun getUserById(id: Long): Mono<UserCredentials> =
         gatewayUserRepository.findById(id).map { it.toCredentials().copy(encodedPassword = "") }
+
+    companion object {
+        private const val CONNECT_TIMEOUT_MS = 3_000
+        private const val RESPONSE_TIMEOUT_SECONDS = 10L
+    }
 }

--- a/edukate-gateway/src/main/resources/application.yml
+++ b/edukate-gateway/src/main/resources/application.yml
@@ -41,13 +41,10 @@ spring:
     pool:
       initial-size: 1
       max-size: 3
-  flyway:
-    enabled: false
   profiles:
     default: prod,secure
   web:
     error:
-      include-message: always
       path: /error
   cloud:
     gateway:
@@ -88,7 +85,7 @@ management:
       probes:
         enabled: true
     prometheus:
-      access: unrestricted
+      access: read_only
   metrics:
     tags:
       application: ${spring.application.name}

--- a/edukate-notifier/src/main/resources/application-dev.properties
+++ b/edukate-notifier/src/main/resources/application-dev.properties
@@ -1,5 +1,6 @@
 spring.mongodb.uri=mongodb://admin:secret@localhost:27017/edukate-notifier?authSource=admin
 spring.docker.compose.enabled=false
+spring.web.error.include-message=always
 
 springdoc.swagger-ui.enabled=false
 springdoc.swagger-ui.path=/swagger/notifier

--- a/edukate-notifier/src/main/resources/application.properties
+++ b/edukate-notifier/src/main/resources/application.properties
@@ -6,10 +6,9 @@ server.port=5820
 
 management.server.port=5821
 management.endpoints.web.exposure.include=health,info,loggers,prometheus
-management.endpoint.prometheus.access=unrestricted
+management.endpoint.prometheus.access=read_only
 management.metrics.tags.application=${spring.application.name}
 logging.group.edukate=io.github.sanyavertolet
-spring.web.error.include-message=always
 
 springdoc.api-docs.enabled=true
 springdoc.api-docs.path=/swagger/notifier/api-docs


### PR DESCRIPTION
### What's done:
 * Adjusted cache expiration for `user-credentials-by-id` to 5 minutes.
 * Enhanced `WebClient` in `BackendService` with timeout configurations.
 * Updated Prometheus endpoint access across multiple modules from `unrestricted` to `read_only`.
 * Reintroduced `spring.web.error.include-message` in development properties for better debugging.