### PR TITLE
Add component tests for ProblemSet and Submission features

### DIFF
--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemSetControllerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemSetControllerTest.kt
@@ -84,7 +84,7 @@ class ProblemSetControllerTest {
     fun `getPublicProblemSets returns 200 with metadata list (no auth required)`() {
         val ps = BackendFixtures.problemSet(isPublic = true)
         every { problemSetService.getPublicProblemSets(any()) } returns Flux.just(ps)
-        every { problemSetMapper.toMetadata(ps) } returns Mono.just(psMetadata())
+        every { problemSetMapper.toMetadata(ps, any()) } returns Mono.just(psMetadata())
 
         webTestClient
             .get()
@@ -104,7 +104,7 @@ class ProblemSetControllerTest {
     fun `getOwnedProblemSets returns 200 with owned metadata`() {
         val ps = BackendFixtures.problemSet()
         every { problemSetService.getOwnedProblemSets(any(), any()) } returns Flux.just(ps)
-        every { problemSetMapper.toMetadata(ps) } returns Mono.just(psMetadata())
+        every { problemSetMapper.toMetadata(ps, any()) } returns Mono.just(psMetadata())
 
         authenticatedClient()
             .get()
@@ -155,7 +155,7 @@ class ProblemSetControllerTest {
     fun `getJoinedProblemSets returns 200 with joined metadata`() {
         val ps = BackendFixtures.problemSet()
         every { problemSetService.getJoinedProblemSets(any(), any()) } returns Flux.just(ps)
-        every { problemSetMapper.toMetadata(ps) } returns Mono.just(psMetadata())
+        every { problemSetMapper.toMetadata(ps, any()) } returns Mono.just(psMetadata())
 
         authenticatedClient()
             .get()

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/UserControllerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/UserControllerTest.kt
@@ -4,6 +4,7 @@ package io.github.sanyavertolet.edukate.backend.controllers
 
 import com.ninjasquad.springmockk.MockkBean
 import io.github.sanyavertolet.edukate.backend.BackendFixtures
+import io.github.sanyavertolet.edukate.backend.services.ProblemSetService
 import io.github.sanyavertolet.edukate.backend.services.UserService
 import io.github.sanyavertolet.edukate.common.security.NoopWebSecurityConfig
 import io.mockk.every
@@ -23,6 +24,7 @@ class UserControllerTest {
     @Autowired private lateinit var webTestClient: WebTestClient
 
     @MockkBean private lateinit var userService: UserService
+    @Suppress("unused") @MockkBean private lateinit var problemSetService: ProblemSetService
 
     private fun authenticatedClient(): WebTestClient =
         webTestClient.mutateWith(

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetDescriptionTab.test.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetDescriptionTab.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@/test/render";
+import { ProblemSetDescriptionTab } from "./ProblemSetDescriptionTab";
+import { ProblemSet } from "@/features/problem-sets/types";
+import { ProblemMetadata } from "@/features/problems/types";
+
+function makeProblem(status: ProblemMetadata["status"], code: string = "1.1"): ProblemMetadata {
+    return { key: `savchenko/${code}`, code, bookSlug: "savchenko", isHard: false, tags: [], status };
+}
+
+const baseProblemSet: ProblemSet = {
+    name: "Mechanics",
+    description: "Classical mechanics problems",
+    admins: ["alice", "bob"],
+    isPublic: true,
+    shareCode: "MECH01",
+    problems: [
+        makeProblem("SOLVED", "1.1"),
+        makeProblem("FAILED", "1.2"),
+        makeProblem("SOLVING", "1.3"),
+        makeProblem("NOT_SOLVED", "1.4"),
+    ],
+};
+
+describe("ProblemSetDescriptionTab", () => {
+    it("shows description text", () => {
+        render(<ProblemSetDescriptionTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("Classical mechanics problems")).toBeInTheDocument();
+    });
+
+    it("hides description when not provided", () => {
+        render(<ProblemSetDescriptionTab problemSet={{ ...baseProblemSet, description: undefined }} />);
+        expect(screen.queryByText("Classical mechanics problems")).not.toBeInTheDocument();
+    });
+
+    it("computes correct progress percentage", () => {
+        render(<ProblemSetDescriptionTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("1 of 4 problems solved (25%)")).toBeInTheDocument();
+    });
+
+    it("shows 100% when all problems are solved", () => {
+        const allSolved: ProblemSet = {
+            ...baseProblemSet,
+            problems: [makeProblem("SOLVED", "1.1"), makeProblem("SOLVED", "1.2")],
+        };
+        render(<ProblemSetDescriptionTab problemSet={allSolved} />);
+        expect(screen.getByText("2 of 2 problems solved (100%)")).toBeInTheDocument();
+    });
+
+    it("shows 0% when no problems are solved", () => {
+        const noneSolved: ProblemSet = {
+            ...baseProblemSet,
+            problems: [makeProblem("NOT_SOLVED", "1.1"), makeProblem("FAILED", "1.2")],
+        };
+        render(<ProblemSetDescriptionTab problemSet={noneSolved} />);
+        expect(screen.getByText("0 of 2 problems solved (0%)")).toBeInTheDocument();
+    });
+
+    it("renders correct status breakdown counts", () => {
+        render(<ProblemSetDescriptionTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("1 Solved")).toBeInTheDocument();
+        expect(screen.getByText("1 Failed")).toBeInTheDocument();
+        expect(screen.getByText("1 Pending")).toBeInTheDocument();
+        expect(screen.getByText("1 Todo")).toBeInTheDocument();
+    });
+
+    it("shows share code", () => {
+        render(<ProblemSetDescriptionTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("MECH01")).toBeInTheDocument();
+    });
+
+    it("shows Public for public problem sets", () => {
+        render(<ProblemSetDescriptionTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("Public")).toBeInTheDocument();
+    });
+
+    it("shows Private for private problem sets", () => {
+        render(<ProblemSetDescriptionTab problemSet={{ ...baseProblemSet, isPublic: false }} />);
+        expect(screen.getByText("Private")).toBeInTheDocument();
+    });
+
+    it("renders admin avatars", () => {
+        render(<ProblemSetDescriptionTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("al")).toBeInTheDocument();
+        expect(screen.getByText("bo")).toBeInTheDocument();
+    });
+});

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetSettingsTab.test.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetSettingsTab.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@/test/render";
+import { server } from "@/test/server";
+import { getGetUserRolesMockHandler, getGetInvitedUsersMockHandler } from "@/generated/backend";
+import { ProblemSetSettingsTab } from "./ProblemSetSettingsTab";
+import { ProblemSet } from "@/features/problem-sets/types";
+import { ProblemMetadata } from "@/features/problems/types";
+
+function makeProblem(status: ProblemMetadata["status"], code: string = "1.1"): ProblemMetadata {
+    return { key: `savchenko/${code}`, code, bookSlug: "savchenko", isHard: false, tags: [], status };
+}
+
+const baseProblemSet: ProblemSet = {
+    name: "Mechanics",
+    description: "Classical mechanics",
+    admins: ["alice"],
+    isPublic: true,
+    shareCode: "MECH01",
+    problems: [makeProblem("SOLVED", "1.1"), makeProblem("NOT_SOLVED", "1.2"), makeProblem("NOT_SOLVED", "1.3")],
+};
+
+describe("ProblemSetSettingsTab", () => {
+    beforeEach(() => {
+        server.use(getGetUserRolesMockHandler([]), getGetInvitedUsersMockHandler([]));
+    });
+
+    it("shows problem set name in the summary header", () => {
+        render(<ProblemSetSettingsTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("Mechanics")).toBeInTheDocument();
+    });
+
+    it("shows total problem count", () => {
+        render(<ProblemSetSettingsTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("3 problems")).toBeInTheDocument();
+    });
+
+    it("shows solved/total progress", () => {
+        render(<ProblemSetSettingsTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("1/3 solved")).toBeInTheDocument();
+    });
+
+    it("shows share code chip", () => {
+        render(<ProblemSetSettingsTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("MECH01")).toBeInTheDocument();
+    });
+
+    it("shows Public label when problem set is public", () => {
+        render(<ProblemSetSettingsTab problemSet={baseProblemSet} />);
+        expect(screen.getByText("Public")).toBeInTheDocument();
+        expect(screen.getByText("Anyone can find and join this problem set.")).toBeInTheDocument();
+    });
+
+    it("shows Private label when problem set is private", () => {
+        render(<ProblemSetSettingsTab problemSet={{ ...baseProblemSet, isPublic: false }} />);
+        expect(screen.getByText("Private")).toBeInTheDocument();
+        expect(screen.getByText("Only invited users can access this problem set.")).toBeInTheDocument();
+    });
+
+    it("renders visibility switch checked when public", () => {
+        render(<ProblemSetSettingsTab problemSet={baseProblemSet} />);
+        const switchEl = screen.getByRole("checkbox");
+        expect(switchEl).toBeChecked();
+    });
+
+    it("renders visibility switch unchecked when private", () => {
+        render(<ProblemSetSettingsTab problemSet={{ ...baseProblemSet, isPublic: false }} />);
+        const switchEl = screen.getByRole("checkbox");
+        expect(switchEl).not.toBeChecked();
+    });
+});

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetUserManagement.test.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetUserManagement.test.tsx
@@ -1,0 +1,101 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen, waitFor } from "@/test/render";
+import { server } from "@/test/server";
+import { getGetUserRolesMockHandler, getGetInvitedUsersMockHandler } from "@/generated/backend";
+import { ProblemSetUserManagement } from "./ProblemSetUserManagement";
+import { UserNameWithRole } from "@/generated/backend";
+
+const members: UserNameWithRole[] = [
+    { name: "alice", role: "ADMIN" },
+    { name: "bob", role: "MODERATOR" },
+    { name: "charlie", role: "USER" },
+];
+
+describe("ProblemSetUserManagement", () => {
+    it("shows member names after data loads", async () => {
+        server.use(getGetUserRolesMockHandler(members), getGetInvitedUsersMockHandler([]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        expect(await screen.findByText("alice")).toBeInTheDocument();
+        expect(screen.getByText("bob")).toBeInTheDocument();
+        expect(screen.getByText("charlie")).toBeInTheDocument();
+    });
+
+    it("shows role chips with correct labels", async () => {
+        server.use(getGetUserRolesMockHandler(members), getGetInvitedUsersMockHandler([]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        expect(await screen.findByText("Admin")).toBeInTheDocument();
+        expect(screen.getByText("Moderator")).toBeInTheDocument();
+        expect(screen.getByText("User")).toBeInTheDocument();
+    });
+
+    it("shows Members section header", async () => {
+        server.use(getGetUserRolesMockHandler(members), getGetInvitedUsersMockHandler([]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        expect(await screen.findByText("Members")).toBeInTheDocument();
+    });
+
+    it("shows 'No members yet' when member list is empty", async () => {
+        server.use(getGetUserRolesMockHandler([]), getGetInvitedUsersMockHandler([]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        expect(await screen.findByText("No members yet")).toBeInTheDocument();
+    });
+
+    it("shows Pending Invitations section when invites exist", async () => {
+        server.use(getGetUserRolesMockHandler([]), getGetInvitedUsersMockHandler(["dave", "eve"]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        expect(await screen.findByText("Pending Invitations")).toBeInTheDocument();
+        expect(screen.getByText("dave")).toBeInTheDocument();
+        expect(screen.getByText("eve")).toBeInTheDocument();
+    });
+
+    it("hides Pending Invitations section when no invites", async () => {
+        server.use(getGetUserRolesMockHandler(members), getGetInvitedUsersMockHandler([]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        await screen.findByText("alice");
+        expect(screen.queryByText("Pending Invitations")).not.toBeInTheDocument();
+    });
+
+    it("opens confirmation dialog when trash icon is clicked for a member", async () => {
+        server.use(getGetUserRolesMockHandler(members), getGetInvitedUsersMockHandler([]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        await screen.findByText("charlie");
+
+        const removeButtons = screen.getAllByLabelText("remove user");
+        await userEvent.click(removeButtons[removeButtons.length - 1]);
+
+        expect(screen.getByText("Remove member")).toBeInTheDocument();
+        expect(screen.getByText(/Are you sure you want to remove charlie/)).toBeInTheDocument();
+    });
+
+    it("opens confirmation dialog when trash icon is clicked for an invited user", async () => {
+        server.use(getGetUserRolesMockHandler([]), getGetInvitedUsersMockHandler(["dave"]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        await screen.findByText("dave");
+
+        await userEvent.click(screen.getByLabelText("remove invitation"));
+
+        expect(screen.getByText("Cancel invitation")).toBeInTheDocument();
+        expect(screen.getByText(/Are you sure you want to cancel the invitation for dave/)).toBeInTheDocument();
+    });
+
+    it("closes confirmation dialog on Cancel click", async () => {
+        server.use(getGetUserRolesMockHandler(members), getGetInvitedUsersMockHandler([]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        await screen.findByText("charlie");
+
+        const removeButtons = screen.getAllByLabelText("remove user");
+        await userEvent.click(removeButtons[removeButtons.length - 1]);
+        expect(screen.getByText("Remove member")).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole("button", { name: "Cancel" }));
+        await waitFor(() => {
+            expect(screen.queryByText("Remove member")).not.toBeInTheDocument();
+        });
+    });
+
+    it("shows Pending chip for invited users", async () => {
+        server.use(getGetUserRolesMockHandler([]), getGetInvitedUsersMockHandler(["dave"]));
+        render(<ProblemSetUserManagement shareCode="TEST01" />);
+        expect(await screen.findByText("Pending")).toBeInTheDocument();
+    });
+});

--- a/edukate-frontend/src/features/submissions/components/SubmissionListItems.tsx
+++ b/edukate-frontend/src/features/submissions/components/SubmissionListItems.tsx
@@ -124,11 +124,7 @@ export function StubListItem() {
             </ListItemAvatar>
             <ListItemText
                 primary={<Skeleton variant="text" width="40%" />}
-                secondary={
-                    <Box sx={{ mt: 0.5 }}>
-                        <Skeleton variant="text" width="25%" />
-                    </Box>
-                }
+                secondary={<Skeleton variant="text" width="25%" sx={{ mt: 0.5 }} />}
             />
         </ListItem>
     );


### PR DESCRIPTION
### What's done:
 * Created unit tests for `ProblemSetDescriptionTab` to validate description rendering, progress calculation, and admin visibility.
 * Added tests for `ProblemSetSettingsTab` to verify problem count, progress, and visibility toggles.
 * Implemented tests for `ProblemSetUserManagement` to ensure member management functionalities, including role display, invitations, and removal dialogs.
 * Fixed minor styling issue in `SubmissionListItems` by simplifying `secondary` skeleton rendering.
 * Updated `ProblemSetControllerTest` to extend `toMetadata` method calls with additional parameters.