### PR TITLE
Frontend & storage improvements: S3 optimization, public problem sets, theme polishing

### DIFF
--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/files/FileManager.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/files/FileManager.kt
@@ -8,6 +8,7 @@ import io.github.sanyavertolet.edukate.backend.storage.FileKeyStorage
 import io.github.sanyavertolet.edukate.storage.keys.FileKey
 import java.nio.ByteBuffer
 import java.time.Duration
+import java.time.Instant
 import org.slf4j.LoggerFactory
 import org.springframework.cache.annotation.CacheEvict
 import org.springframework.cache.annotation.Cacheable
@@ -43,10 +44,15 @@ class FileManager(private val fileObjectRepository: FileObjectRepository, privat
 
     @Transactional
     fun uploadFile(key: FileKey, contentType: MediaType, content: Flux<ByteBuffer>): Mono<FileKey> =
-        storage
-            .upload(key, contentType.toString(), content)
-            .flatMap { k ->
-                storage.metadata(k).flatMap { meta -> saveOrUpdateByKeyPath(k.toString(), k, meta) }.thenReturn(k)
+        content
+            .collectList()
+            .flatMap { buffers ->
+                val contentLength = buffers.sumOf { it.remaining().toLong() }
+                val contentTypeStr = contentType.toString()
+                storage.upload(key, contentLength, contentTypeStr, Flux.fromIterable(buffers)).flatMap { k ->
+                    val meta = FileObjectMetadata(Instant.now(), contentLength, contentTypeStr)
+                    saveOrUpdateByKeyPath(k.toString(), k, meta).thenReturn(k)
+                }
             }
             .timeout(DEFAULT_TIMEOUT)
             .doOnSubscribe { log.debug("Uploading: key={}", key) }

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/FileManagerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/FileManagerTest.kt
@@ -94,11 +94,9 @@ class FileManagerTest {
     @Test
     fun `uploadFile saves Metadata to db`() {
         val key = TempFileKey(1L, "file.txt")
-        val metadata = meta()
-        val content = Flux.empty<ByteBuffer>()
+        val content = Flux.just(ByteBuffer.wrap("hello".toByteArray()))
 
-        every { storage.upload(key, "text/plain", content) } returns Mono.just(key)
-        every { storage.metadata(key) } returns Mono.just(metadata)
+        every { storage.upload(key, any<Long>(), "text/plain", any()) } returns Mono.just(key)
         every { fileObjectRepository.findByKeyPath(key.toString()) } returns Mono.empty()
         every { fileObjectRepository.save(any()) } answers { Mono.just(firstArg()) }
 
@@ -112,13 +110,11 @@ class FileManagerTest {
     @Test
     fun `uploadFile updates existing file object`() {
         val key = TempFileKey(1L, "file.txt")
-        val metadata = meta()
-        val content = Flux.empty<ByteBuffer>()
+        val content = Flux.just(ByteBuffer.wrap("hello".toByteArray()))
         val existingFo =
             FileObject(id = 10L, keyPath = key.toString(), key = key, type = "tmp", ownerUserId = 1L, metadata = meta(50L))
 
-        every { storage.upload(key, "text/plain", content) } returns Mono.just(key)
-        every { storage.metadata(key) } returns Mono.just(metadata)
+        every { storage.upload(key, any<Long>(), "text/plain", any()) } returns Mono.just(key)
         every { fileObjectRepository.findByKeyPath(key.toString()) } returns Mono.just(existingFo)
         every { fileObjectRepository.save(any()) } answers { Mono.just(firstArg()) }
 

--- a/edukate-checker/src/main/kotlin/io/github/sanyavertolet/edukate/checker/services/MediaContentResolver.kt
+++ b/edukate-checker/src/main/kotlin/io/github/sanyavertolet/edukate/checker/services/MediaContentResolver.kt
@@ -5,7 +5,6 @@ import java.nio.ByteBuffer
 import org.springframework.ai.content.Media
 import org.springframework.core.io.buffer.DataBufferUtils
 import org.springframework.core.io.buffer.DefaultDataBufferFactory
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -14,9 +13,10 @@ import reactor.core.publisher.Mono
 class MediaContentResolver(private val storage: RawKeyReadOnlyStorage) {
     fun resolveMedia(rawKeys: List<String>): Flux<Media> = Flux.fromIterable(rawKeys).flatMapSequential(::resolveMedia)
 
-    // fixme: storage should return metadata from ReadOnlyStorage#getContent
     private fun resolveMedia(rawKey: String): Mono<Media> =
-        toByteArray(storage.getContent(rawKey)).zipWith(storage.metadata(rawKey), ::mediaWithByteArray)
+        storage.getContentWithMetadata(rawKey).flatMap { (mediaType, content) ->
+            toByteArray(content).map { bytes -> Media.builder().mimeType(mediaType).data(bytes).build() }
+        }
 
     private fun toByteArray(input: Flux<ByteBuffer>): Mono<ByteArray> =
         DataBufferUtils.join(input.map(DefaultDataBufferFactory.sharedInstance::wrap)).map { db ->
@@ -25,7 +25,4 @@ class MediaContentResolver(private val storage: RawKeyReadOnlyStorage) {
             DataBufferUtils.release(db)
             bytes
         }
-
-    private fun mediaWithByteArray(data: ByteArray, mediaType: MediaType): Media =
-        Media.builder().mimeType(mediaType).data(data).build()
 }

--- a/edukate-checker/src/test/kotlin/io/github/sanyavertolet/edukate/checker/components/MediaContentResolverTest.kt
+++ b/edukate-checker/src/test/kotlin/io/github/sanyavertolet/edukate/checker/components/MediaContentResolverTest.kt
@@ -4,6 +4,7 @@ package io.github.sanyavertolet.edukate.checker.components
 
 import io.github.sanyavertolet.edukate.checker.services.MediaContentResolver
 import io.github.sanyavertolet.edukate.checker.storage.RawKeyReadOnlyStorage
+import io.github.sanyavertolet.edukate.storage.ContentWithMetadata
 import io.mockk.every
 import io.mockk.mockk
 import java.nio.ByteBuffer
@@ -14,6 +15,7 @@ import org.springframework.http.MediaType
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
+import software.amazon.awssdk.services.s3.model.S3Exception
 
 class MediaContentResolverTest {
     private val storage = mockk<RawKeyReadOnlyStorage>()
@@ -24,6 +26,9 @@ class MediaContentResolverTest {
         resolver = MediaContentResolver(storage)
     }
 
+    private fun contentWithMetadata(bytes: ByteArray, mediaType: MediaType) =
+        ContentWithMetadata(mediaType, Flux.just(ByteBuffer.wrap(bytes)))
+
     @Test
     fun `empty key list returns empty Flux`() {
         StepVerifier.create(resolver.resolveMedia(emptyList())).verifyComplete()
@@ -32,8 +37,7 @@ class MediaContentResolverTest {
     @Test
     fun `single key fetches bytes and builds Media`() {
         val bytes = "image data".toByteArray()
-        every { storage.getContent("key1") } returns Flux.just(ByteBuffer.wrap(bytes))
-        every { storage.metadata("key1") } returns Mono.just(MediaType.IMAGE_JPEG)
+        every { storage.getContentWithMetadata("key1") } returns Mono.just(contentWithMetadata(bytes, MediaType.IMAGE_JPEG))
 
         StepVerifier.create(resolver.resolveMedia(listOf("key1")))
             .assertNext { media ->
@@ -46,8 +50,7 @@ class MediaContentResolverTest {
     @Test
     fun `metadata MediaType is passed to Media`() {
         val bytes = "img".toByteArray()
-        every { storage.getContent("key1") } returns Flux.just(ByteBuffer.wrap(bytes))
-        every { storage.metadata("key1") } returns Mono.just(MediaType.IMAGE_PNG)
+        every { storage.getContentWithMetadata("key1") } returns Mono.just(contentWithMetadata(bytes, MediaType.IMAGE_PNG))
 
         StepVerifier.create(resolver.resolveMedia(listOf("key1")))
             .assertNext { media -> assertThat(media.mimeType).isEqualTo(MediaType.IMAGE_PNG) }
@@ -58,8 +61,8 @@ class MediaContentResolverTest {
     fun `multiple keys return one Media per key in order`() {
         val keys = listOf("key1", "key2", "key3")
         keys.forEach { key ->
-            every { storage.getContent(key) } returns Flux.just(ByteBuffer.wrap("data".toByteArray()))
-            every { storage.metadata(key) } returns Mono.just(MediaType.IMAGE_JPEG)
+            every { storage.getContentWithMetadata(key) } returns
+                Mono.just(contentWithMetadata("data".toByteArray(), MediaType.IMAGE_JPEG))
         }
 
         StepVerifier.create(resolver.resolveMedia(keys)).expectNextCount(3).verifyComplete()
@@ -67,9 +70,9 @@ class MediaContentResolverTest {
 
     @Test
     fun `S3 error propagates`() {
-        every { storage.getContent("key1") } returns Flux.error(RuntimeException("S3 unavailable"))
-        every { storage.metadata("key1") } returns Mono.just(MediaType.IMAGE_JPEG)
+        val s3Error = S3Exception.builder().message("S3 unavailable").statusCode(500).build()
+        every { storage.getContentWithMetadata("key1") } returns Mono.error(s3Error)
 
-        StepVerifier.create(resolver.resolveMedia(listOf("key1"))).expectError(RuntimeException::class.java).verify()
+        StepVerifier.create(resolver.resolveMedia(listOf("key1"))).expectError(S3Exception::class.java).verify()
     }
 }

--- a/edukate-common/src/main/kotlin/io/github/sanyavertolet/edukate/common/utils/PublicEndpoints.kt
+++ b/edukate-common/src/main/kotlin/io/github/sanyavertolet/edukate/common/utils/PublicEndpoints.kt
@@ -13,7 +13,8 @@ object PublicEndpoints {
             "/api/v1/auth/*",
             "/swagger/**",
             "/swagger-ui/**",
-            "/api/v1/bundles/public",
+            "/api/v1/problem-sets/public",
+            "/api/v1/problem-sets/*",
         )
 
     val exchangeMatcher: ServerWebExchangeMatcher =

--- a/edukate-frontend/src/app/router.tsx
+++ b/edukate-frontend/src/app/router.tsx
@@ -52,11 +52,7 @@ export const router = createBrowserRouter([
             },
             {
                 path: "/problem-sets/:code",
-                element: (
-                    <AuthRequired>
-                        <ProblemSetPage />
-                    </AuthRequired>
-                ),
+                element: <ProblemSetPage />,
             },
             {
                 path: "/submissions/:id",

--- a/edukate-frontend/src/features/files/components/FileDragAndDrop.tsx
+++ b/edukate-frontend/src/features/files/components/FileDragAndDrop.tsx
@@ -13,7 +13,7 @@ type FileDragAndDropProps = {
 };
 
 const headerListItemSx = {
-    backgroundColor: "rgb(0,0,0,0.04)",
+    backgroundColor: "action.hover",
     mb: 1,
     borderRadius: 1,
     border: "1px solid",

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetListItem.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetListItem.tsx
@@ -47,7 +47,7 @@ export const ProblemSetListItem: FC<ProblemSetListItemProps> = ({ problemSetMeta
                                 variant="determinate"
                                 value={percentage}
                                 color={isComplete ? "success" : "primary"}
-                                sx={{ width: { xs: 60, sm: 100, md: 120 }, height: 6, borderRadius: 3 }}
+                                sx={{ width: { xs: 60, sm: 100, md: 120 } }}
                             />
                             <Typography variant="caption" color="text.secondary" noWrap>
                                 {problemSetMetadata.solvedCount}/{problemSetMetadata.size} solved

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetSettingsTab.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetSettingsTab.tsx
@@ -42,7 +42,7 @@ export const ProblemSetSettingsTab: FC<ProblemSetSettingsTabProps> = ({ problemS
                             variant="determinate"
                             value={percentage}
                             color={percentage === 100 ? "success" : "primary"}
-                            sx={{ flexGrow: 1, height: 6, borderRadius: 3 }}
+                            sx={{ flexGrow: 1 }}
                         />
                         <Typography variant="caption" color="text.secondary" noWrap>
                             {solved}/{total} solved

--- a/edukate-frontend/src/features/problems/components/table/ProblemTableToolbar.tsx
+++ b/edukate-frontend/src/features/problems/components/table/ProblemTableToolbar.tsx
@@ -65,18 +65,105 @@ export const ProblemTableToolbar: FC<Props> = ({
 }) => {
     const { isAuthorized } = useAuthContext();
     return (
-        <Toolbar sx={{ display: "flex", gap: 2, justifyContent: "space-between", flexWrap: "wrap" }}>
-            <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
-                <TextField
-                    label="Search by prefix"
-                    size="small"
-                    value={prefix}
-                    onChange={(e) => {
-                        onPrefixChange(e.target.value);
-                    }}
-                />
+        <Box>
+            <Toolbar sx={{ display: "flex", gap: 2, justifyContent: "space-between", flexWrap: "wrap" }}>
+                <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
+                    <TextField
+                        label="Search by prefix"
+                        size="small"
+                        value={prefix}
+                        onChange={(e) => {
+                            onPrefixChange(e.target.value);
+                        }}
+                    />
 
-                {bookSlug && (
+                    {isAuthorized && (
+                        <FormControl size="small" sx={{ minWidth: 160 }}>
+                            <InputLabel size={"small"} id="status-filter-label">
+                                Status
+                            </InputLabel>
+                            <Select
+                                labelId="status-filter-label"
+                                size={"small"}
+                                label="Status"
+                                value={status ?? "ALL"}
+                                onChange={(e) => {
+                                    onStatusChange((e.target.value || "ALL") as StatusFilter);
+                                }}
+                            >
+                                <MenuItem value="ALL">All</MenuItem>
+                                <MenuItem value="SOLVED">
+                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                        <DoneIcon color="success" fontSize="small" />
+                                        Solved
+                                    </Box>
+                                </MenuItem>
+                                <MenuItem value="SOLVING">
+                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                        <PendingIcon color="warning" fontSize="small" />
+                                        Solving
+                                    </Box>
+                                </MenuItem>
+                                <MenuItem value="FAILED">
+                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                        <CloseIcon color="error" fontSize="small" />
+                                        Failed
+                                    </Box>
+                                </MenuItem>
+                                <MenuItem value="NOT_SOLVED">Not solved</MenuItem>
+                            </Select>
+                        </FormControl>
+                    )}
+
+                    <FormControl size="small" sx={{ minWidth: 130 }}>
+                        <InputLabel size={"small"} id="difficulty-filter-label">
+                            Difficulty
+                        </InputLabel>
+                        <Select
+                            labelId="difficulty-filter-label"
+                            size={"small"}
+                            label="Difficulty"
+                            value={difficultyToSelectValue(isHard)}
+                            onChange={(e) => {
+                                onIsHardChange(selectValueToDifficulty(e.target.value));
+                            }}
+                        >
+                            <MenuItem value="ANY">Any</MenuItem>
+                            <MenuItem value="HARD">Hard</MenuItem>
+                            <MenuItem value="MEDIUM">Medium</MenuItem>
+                        </Select>
+                    </FormControl>
+
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={!!hasPictures}
+                                onChange={(e) => {
+                                    onHasPicturesChange(e.target.checked);
+                                }}
+                            />
+                        }
+                        label="With pictures"
+                    />
+
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                checked={!!hasResult}
+                                onChange={(e) => {
+                                    onHasResultChange(e.target.checked);
+                                }}
+                            />
+                        }
+                        label="With answer"
+                    />
+                </Box>
+
+                <Box sx={{ marginLeft: "auto" }}>{rightSlot}</Box>
+            </Toolbar>
+
+            {bookSlug && (
+                <Box sx={{ px: 3, pb: 1, display: "flex", justifyContent: "flex-start" }}>
                     <Chip
                         label={`Book: ${bookSlug}`}
                         onDelete={() => {
@@ -84,92 +171,10 @@ export const ProblemTableToolbar: FC<Props> = ({
                         }}
                         color="primary"
                         variant="outlined"
+                        size="small"
                     />
-                )}
-
-                {isAuthorized && (
-                    <FormControl size="small" sx={{ minWidth: 160 }}>
-                        <InputLabel size={"small"} id="status-filter-label">
-                            Status
-                        </InputLabel>
-                        <Select
-                            labelId="status-filter-label"
-                            size={"small"}
-                            label="Status"
-                            value={status ?? "ALL"}
-                            onChange={(e) => {
-                                onStatusChange((e.target.value || "ALL") as StatusFilter);
-                            }}
-                        >
-                            <MenuItem value="ALL">All</MenuItem>
-                            <MenuItem value="SOLVED">
-                                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                    <DoneIcon color="success" fontSize="small" />
-                                    Solved
-                                </Box>
-                            </MenuItem>
-                            <MenuItem value="SOLVING">
-                                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                    <PendingIcon color="warning" fontSize="small" />
-                                    Solving
-                                </Box>
-                            </MenuItem>
-                            <MenuItem value="FAILED">
-                                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                    <CloseIcon color="error" fontSize="small" />
-                                    Failed
-                                </Box>
-                            </MenuItem>
-                            <MenuItem value="NOT_SOLVED">Not solved</MenuItem>
-                        </Select>
-                    </FormControl>
-                )}
-
-                <FormControl size="small" sx={{ minWidth: 130 }}>
-                    <InputLabel size={"small"} id="difficulty-filter-label">
-                        Difficulty
-                    </InputLabel>
-                    <Select
-                        labelId="difficulty-filter-label"
-                        size={"small"}
-                        label="Difficulty"
-                        value={difficultyToSelectValue(isHard)}
-                        onChange={(e) => {
-                            onIsHardChange(selectValueToDifficulty(e.target.value));
-                        }}
-                    >
-                        <MenuItem value="ANY">Any</MenuItem>
-                        <MenuItem value="HARD">Hard</MenuItem>
-                        <MenuItem value="MEDIUM">Medium</MenuItem>
-                    </Select>
-                </FormControl>
-
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={!!hasPictures}
-                            onChange={(e) => {
-                                onHasPicturesChange(e.target.checked);
-                            }}
-                        />
-                    }
-                    label="With pictures"
-                />
-
-                <FormControlLabel
-                    control={
-                        <Checkbox
-                            checked={!!hasResult}
-                            onChange={(e) => {
-                                onHasResultChange(e.target.checked);
-                            }}
-                        />
-                    }
-                    label="With answer"
-                />
-            </Box>
-
-            <Box sx={{ marginLeft: "auto" }}>{rightSlot}</Box>
-        </Toolbar>
+                </Box>
+            )}
+        </Box>
     );
 };

--- a/edukate-frontend/src/pages/ProblemSetListPage.tsx
+++ b/edukate-frontend/src/pages/ProblemSetListPage.tsx
@@ -9,7 +9,7 @@ import { AuthRequired } from "@/features/auth/components/AuthRequired";
 
 export default function ProblemSetListPage() {
     const { isAuthorized } = useAuthContext();
-    const [tab, setTab] = useState<ProblemSetCategory>(isAuthorized ? "owned" : "public");
+    const [tab, setTab] = useState<ProblemSetCategory>("public");
 
     const onTabChange = (_: SyntheticEvent, newValue: ProblemSetCategory) => {
         setTab(newValue);
@@ -28,9 +28,9 @@ export default function ProblemSetListPage() {
                     <ProblemSetToolbar disabled={!isAuthorized} />
 
                     <Tabs value={tab} onChange={onTabChange} centered sx={{ mt: 2 }}>
+                        <Tab value={"public"} label="Public" />
                         <Tab value={"joined"} label="Joined" />
                         <Tab value={"owned"} label="Owned" />
-                        <Tab value={"public"} label="Public" />
                     </Tabs>
                 </Box>
             </Container>

--- a/edukate-frontend/src/shared/components/Particles.tsx
+++ b/edukate-frontend/src/shared/components/Particles.tsx
@@ -43,10 +43,10 @@ export default function ParticlesComponent() {
             },
             particles: {
                 color: {
-                    value: "#851691",
+                    value: themes[theme].palette.primary.main,
                 },
                 links: {
-                    color: "#007E8A",
+                    color: themes[theme].palette.secondary.main,
                     distance: 125,
                     enable: true,
                     opacity: 0.25,

--- a/edukate-frontend/src/shared/components/Styled.ts
+++ b/edukate-frontend/src/shared/components/Styled.ts
@@ -13,7 +13,7 @@ export const BlurryToolbar = styled(Toolbar)(({ theme }) => ({
     borderColor: theme.palette.divider,
     backgroundColor: alpha(theme.palette.background.default, 0.4),
     boxShadow: theme.shadows[1],
-    padding: "8px 12px",
+    padding: theme.spacing(1, 1.5),
 }));
 
 export const SignCard = styled(Card)(({ theme }) => ({
@@ -27,9 +27,9 @@ export const SignCard = styled(Card)(({ theme }) => ({
     [theme.breakpoints.up("sm")]: {
         maxWidth: "450px",
     },
-    boxShadow: "hsla(220, 30%, 5%, 0.05) 0px 5px 15px 0px, hsla(220, 25%, 10%, 0.05) 0px 15px 35px -5px",
+    boxShadow: theme.shadows[2],
     ...theme.applyStyles("dark", {
-        boxShadow: "hsla(220, 30%, 5%, 0.5) 0px 5px 15px 0px, hsla(220, 25%, 10%, 0.08) 0px 15px 35px -5px",
+        boxShadow: theme.shadows[4],
     }),
 }));
 

--- a/edukate-frontend/src/shared/components/images/ImageLightbox.tsx
+++ b/edukate-frontend/src/shared/components/images/ImageLightbox.tsx
@@ -45,9 +45,8 @@ export const ImageLightbox: FC<ImageLightboxProps> = ({ images, index, open, onC
                 doubleClickDelay: 300,
                 scrollToZoom: true,
             }}
-            styles={{
-                container: { backgroundColor: "rgba(0, 0, 0, 0.75)" },
-            }}
+            // Lightbox backdrop — intentionally hardcoded (YARL styles prop doesn't support theme tokens)
+            styles={{ container: { backgroundColor: "rgba(0, 0, 0, 0.75)" } }}
             controller={{ closeOnBackdropClick: true }}
         />
     );

--- a/edukate-frontend/src/shared/components/layout/AppFooter.tsx
+++ b/edukate-frontend/src/shared/components/layout/AppFooter.tsx
@@ -19,6 +19,7 @@ export function AppFooter() {
                 py: 1,
                 opacity: 0.4,
                 pointerEvents: "none",
+                color: "text.primary",
             }}
         >
             <Typography variant="caption">build {buildTime}</Typography>

--- a/edukate-frontend/src/shared/context/themes.ts
+++ b/edukate-frontend/src/shared/context/themes.ts
@@ -1,113 +1,62 @@
 import { createTheme } from "@mui/material/styles";
 
+const typography = {
+    fontFamily: [
+        "-apple-system",
+        "BlinkMacSystemFont",
+        '"Segoe UI"',
+        "Roboto",
+        '"Helvetica Neue"',
+        "Arial",
+        "sans-serif",
+    ].join(","),
+};
+
+const components = {
+    MuiLinearProgress: {
+        styleOverrides: {
+            root: {
+                height: 6,
+                borderRadius: 3,
+            },
+        },
+    },
+};
+
 const lightTheme = createTheme({
     palette: {
+        mode: "light",
         primary: {
             main: "#851691",
         },
         secondary: {
             main: "#007E8A",
         },
-        error: {
-            main: "#d32f2f",
-            light: "#ef5350",
-            dark: "#c62828",
-            contrastText: "#fff",
-        },
-        warning: {
-            main: "#ed6c02",
-            light: "#ff9800",
-            dark: "#e65100",
-            contrastText: "#fff",
-        },
-        info: {
-            main: "#0288d1",
-            light: "#03a9f4",
-            dark: "#01579b",
-            contrastText: "#fff",
-        },
-        success: {
-            main: "#2e7d32",
-            light: "#4caf50",
-            dark: "#1b5e20",
-            contrastText: "#fff",
-        },
         background: {
             default: "#f9ebd9",
             paper: "#f3f1ee",
         },
-        text: {
-            primary: "rgba(0, 0, 0, 0.87)",
-            secondary: "rgba(0, 0, 0, 0.6)",
-            disabled: "rgba(0, 0, 0, 0.38)",
-        },
     },
-    typography: {
-        fontFamily: [
-            "-apple-system",
-            "BlinkMacSystemFont",
-            '"Segoe UI"',
-            "Roboto",
-            '"Helvetica Neue"',
-            "Arial",
-            "sans-serif",
-        ].join(","),
-    },
+    typography,
+    components,
 });
 
 const darkTheme = createTheme({
     palette: {
+        mode: "dark",
         primary: {
-            main: "#677cc5",
+            main: "#9fa8da",
         },
         secondary: {
-            main: "#53d4e1",
-        },
-        error: {
-            main: "#d32f2f",
-            light: "#ef5350",
-            dark: "#c62828",
-            contrastText: "#fff",
-        },
-        warning: {
-            main: "#ed6c02",
-            light: "#ff9800",
-            dark: "#e65100",
-            contrastText: "#fff",
-        },
-        info: {
-            main: "#0288d1",
-            light: "#03a9f4",
-            dark: "#01579b",
-            contrastText: "#fff",
-        },
-        success: {
-            main: "#2e7d32",
-            light: "#4caf50",
-            dark: "#1b5e20",
-            contrastText: "#fff",
+            main: "#80deea",
         },
         background: {
             default: "#36393e",
             paper: "#424549",
         },
-        text: {
-            primary: "rgba(255, 255, 255, 0.87)",
-            secondary: "rgba(255, 255, 255, 0.6)",
-            disabled: "rgba(255, 255, 255, 0.38)",
-        },
     },
-    typography: {
-        fontFamily: [
-            "-apple-system",
-            "BlinkMacSystemFont",
-            '"Segoe UI"',
-            "Roboto",
-            '"Helvetica Neue"',
-            "Arial",
-            "sans-serif",
-        ].join(","),
-    },
+    typography,
+    components,
 });
 
 export default {

--- a/edukate-storage/CLAUDE.md
+++ b/edukate-storage/CLAUDE.md
@@ -6,8 +6,9 @@ Shared library providing a generic S3/MinIO object storage abstraction. Used by 
 
 ### `ReadOnlyStorage<Key, Metadata>`
 
-- `metadata(key)` → object metadata
-- `getContent(key)` → reactive content stream
+- `metadata(key)` → object metadata (HEAD request)
+- `getContent(key)` → reactive content stream (GET request, metadata discarded)
+- `getContentWithMetadata(key)` → `ContentWithMetadata<Metadata>` (single GET request returning both content stream and metadata)
 - `generatePresignedUrl(key)` → temporary download URL
 - `prefixed(prefix)` → list objects by prefix
 
@@ -26,7 +27,7 @@ Shared library providing a generic S3/MinIO object storage abstraction. Used by 
 | `FileKey`           | Generic files           |
 | `ProblemFileKey`    | Problem assets          |
 | `SubmissionFileKey` | User submission files   |
-| `ResultFileKey`     | AI check result files   |
+| `AnswerFileKey`     | Reference answer files  |
 | `TempFileKey`       | Temporary/staging files |
 
 ## Configuration (`S3Properties`)

--- a/edukate-storage/src/main/kotlin/io/github/sanyavertolet/edukate/storage/AbstractReadOnlyStorage.kt
+++ b/edukate-storage/src/main/kotlin/io/github/sanyavertolet/edukate/storage/AbstractReadOnlyStorage.kt
@@ -8,6 +8,7 @@ import reactor.kotlin.core.publisher.toFlux
 import software.amazon.awssdk.core.async.AsyncResponseTransformer
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
@@ -27,6 +28,15 @@ abstract class AbstractReadOnlyStorage<Key : Any, Metadata : Any>(
 
     protected abstract fun buildMetadata(headObjectResponse: HeadObjectResponse): Metadata
 
+    protected open fun buildMetadata(getObjectResponse: GetObjectResponse): Metadata =
+        buildMetadata(
+            HeadObjectResponse.builder()
+                .contentType(getObjectResponse.contentType())
+                .contentLength(getObjectResponse.contentLength())
+                .lastModified(getObjectResponse.lastModified())
+                .build()
+        )
+
     override fun metadata(key: Key): Mono<Metadata> {
         val request = HeadObjectRequest.builder().bucket(s3Properties.bucket).key(key.toString()).build()
 
@@ -45,6 +55,18 @@ abstract class AbstractReadOnlyStorage<Key : Any, Metadata : Any>(
                 if (e.statusCode() == HTTP_NOT_FOUND) Mono.empty() else Mono.error(e)
             }
             .flatMapMany { Flux.from(it) }
+    }
+
+    override fun getContentWithMetadata(key: Key): Mono<ContentWithMetadata<Metadata>> {
+        val request = GetObjectRequest.builder().bucket(s3Properties.bucket).key(key.toString()).build()
+
+        return Mono.fromFuture { s3AsyncClient.getObject(request, AsyncResponseTransformer.toPublisher()) }
+            .onErrorResume(S3Exception::class.java) { e ->
+                if (e.statusCode() == HTTP_NOT_FOUND) Mono.empty() else Mono.error(e)
+            }
+            .map { publisher ->
+                ContentWithMetadata(metadata = buildMetadata(publisher.response()), content = Flux.from(publisher))
+            }
     }
 
     override fun generatePresignedUrl(key: Key): Mono<String> =

--- a/edukate-storage/src/main/kotlin/io/github/sanyavertolet/edukate/storage/ContentWithMetadata.kt
+++ b/edukate-storage/src/main/kotlin/io/github/sanyavertolet/edukate/storage/ContentWithMetadata.kt
@@ -1,0 +1,6 @@
+package io.github.sanyavertolet.edukate.storage
+
+import java.nio.ByteBuffer
+import reactor.core.publisher.Flux
+
+data class ContentWithMetadata<Metadata : Any>(val metadata: Metadata, val content: Flux<ByteBuffer>)

--- a/edukate-storage/src/main/kotlin/io/github/sanyavertolet/edukate/storage/ReadOnlyStorage.kt
+++ b/edukate-storage/src/main/kotlin/io/github/sanyavertolet/edukate/storage/ReadOnlyStorage.kt
@@ -9,6 +9,8 @@ interface ReadOnlyStorage<Key : Any, Metadata : Any> {
 
     fun getContent(key: Key): Flux<ByteBuffer>
 
+    fun getContentWithMetadata(key: Key): Mono<ContentWithMetadata<Metadata>>
+
     fun generatePresignedUrl(key: Key): Mono<String>
 
     fun prefixed(rawKeyPrefix: String): Flux<Key>

--- a/edukate-storage/src/test/kotlin/io/github/sanyavertolet/edukate/storage/AbstractStorageTest.kt
+++ b/edukate-storage/src/test/kotlin/io/github/sanyavertolet/edukate/storage/AbstractStorageTest.kt
@@ -169,9 +169,7 @@ class AbstractStorageTest {
     fun `metadata sends correct bucket and key in request`() {
         every { s3Client.headObject(any<HeadObjectRequest>()) } returns CompletableFuture.completedFuture(headResponse())
 
-        StepVerifier.create(storage.metadata("books/savchenko/problems/1.1.1/img.png"))
-            .expectNextCount(1)
-            .verifyComplete()
+        StepVerifier.create(storage.metadata("books/savchenko/problems/1.1.1/img.png")).expectNextCount(1).verifyComplete()
 
         verify {
             s3Client.headObject(

--- a/edukate-storage/src/test/kotlin/io/github/sanyavertolet/edukate/storage/AbstractStorageTest.kt
+++ b/edukate-storage/src/test/kotlin/io/github/sanyavertolet/edukate/storage/AbstractStorageTest.kt
@@ -1,0 +1,448 @@
+@file:Suppress("ReactiveStreamsUnusedPublisher")
+
+package io.github.sanyavertolet.edukate.storage
+
+import io.github.sanyavertolet.edukate.storage.configs.S3Properties
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.net.URI
+import java.nio.ByteBuffer
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.CompletableFuture
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.reactivestreams.Subscriber
+import reactor.core.publisher.Flux
+import reactor.test.StepVerifier
+import software.amazon.awssdk.core.async.AsyncRequestBody
+import software.amazon.awssdk.core.async.AsyncResponseTransformer
+import software.amazon.awssdk.core.async.ResponsePublisher
+import software.amazon.awssdk.http.SdkHttpResponse
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectResponse
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse
+import software.amazon.awssdk.services.s3.model.GetObjectRequest
+import software.amazon.awssdk.services.s3.model.GetObjectResponse
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response
+import software.amazon.awssdk.services.s3.model.PutObjectRequest
+import software.amazon.awssdk.services.s3.model.PutObjectResponse
+import software.amazon.awssdk.services.s3.model.S3Exception
+import software.amazon.awssdk.services.s3.model.S3Object
+import software.amazon.awssdk.services.s3.paginators.ListObjectsV2Publisher
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest
+
+class AbstractStorageTest {
+    private val s3Client: S3AsyncClient = mockk()
+    private val s3Presigner: S3Presigner = mockk()
+    private val props =
+        S3Properties(
+            endpoint = "http://localhost:9000",
+            region = "us-east-1",
+            accessKey = "test",
+            secretKey = "test",
+            bucket = "test-bucket",
+            signatureDuration = Duration.ofHours(1),
+        )
+
+    private lateinit var storage: TestStorage
+
+    @BeforeEach
+    fun setUp() {
+        storage = TestStorage(s3Client, s3Presigner, props)
+    }
+
+    // region test helpers
+
+    /** Concrete subclass that maps keys to strings and metadata to content type. */
+    class TestStorage(s3Client: S3AsyncClient, presigner: S3Presigner, props: S3Properties) :
+        AbstractStorage<String, String>(s3Client, presigner, props) {
+
+        override fun buildKey(key: String): String = key
+
+        override fun buildMetadata(headObjectResponse: HeadObjectResponse): String = headObjectResponse.contentType()
+    }
+
+    private fun responsePublisher(
+        response: GetObjectResponse,
+        content: List<ByteBuffer>,
+    ): ResponsePublisher<GetObjectResponse> {
+        val publisher = mockk<ResponsePublisher<GetObjectResponse>>()
+        every { publisher.response() } returns response
+        every { publisher.subscribe(any<Subscriber<in ByteBuffer>>()) } answers
+            {
+                Flux.fromIterable(content).subscribe(firstArg<Subscriber<in ByteBuffer>>())
+            }
+        return publisher
+    }
+
+    private fun headResponse(contentType: String = "image/png") =
+        HeadObjectResponse.builder()
+            .contentType(contentType)
+            .contentLength(42L)
+            .lastModified(Instant.parse("2026-01-01T00:00:00Z"))
+            .build()
+
+    private fun getResponse(contentType: String = "image/png") =
+        GetObjectResponse.builder()
+            .contentType(contentType)
+            .contentLength(42L)
+            .lastModified(Instant.parse("2026-01-01T00:00:00Z"))
+            .build()
+
+    private fun s3Error(statusCode: Int, message: String = "error"): S3Exception =
+        S3Exception.builder().statusCode(statusCode).message(message).build() as S3Exception
+
+    private fun successfulHttpResponse(): SdkHttpResponse = SdkHttpResponse.builder().statusCode(200).build()
+
+    private fun mockGetObject(publisher: ResponsePublisher<GetObjectResponse>) {
+        every {
+            s3Client.getObject(any<GetObjectRequest>(), any<AsyncResponseTransformer<GetObjectResponse, Any>>())
+        } returns CompletableFuture.completedFuture(publisher)
+    }
+
+    private fun mockGetObjectError(error: Throwable) {
+        every {
+            s3Client.getObject(any<GetObjectRequest>(), any<AsyncResponseTransformer<GetObjectResponse, Any>>())
+        } returns CompletableFuture.failedFuture(error)
+    }
+
+    private fun listPublisher(vararg keys: String): ListObjectsV2Publisher {
+        val pub = mockk<ListObjectsV2Publisher>()
+        every { pub.subscribe(any<Subscriber<in ListObjectsV2Response>>()) } answers
+            {
+                val response =
+                    ListObjectsV2Response.builder().contents(keys.map { S3Object.builder().key(it).build() }).build()
+                Flux.just(response).subscribe(firstArg<Subscriber<in ListObjectsV2Response>>())
+            }
+        return pub
+    }
+
+    private fun mockDeleteSuccess(): DeleteObjectResponse {
+        val response = mockk<DeleteObjectResponse>()
+        every { response.sdkHttpResponse() } returns successfulHttpResponse()
+        every { s3Client.deleteObject(any<DeleteObjectRequest>()) } returns CompletableFuture.completedFuture(response)
+        return response
+    }
+
+    // endregion
+
+    // region metadata()
+
+    @Test
+    fun `metadata returns mapped value on success`() {
+        every { s3Client.headObject(any<HeadObjectRequest>()) } returns
+            CompletableFuture.completedFuture(headResponse("application/pdf"))
+
+        StepVerifier.create(storage.metadata("some-key"))
+            .assertNext { assertThat(it).isEqualTo("application/pdf") }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `metadata returns empty on 404`() {
+        every { s3Client.headObject(any<HeadObjectRequest>()) } returns CompletableFuture.failedFuture(s3Error(404))
+
+        StepVerifier.create(storage.metadata("missing-key")).verifyComplete()
+    }
+
+    @Test
+    fun `metadata propagates non-404 S3 errors`() {
+        every { s3Client.headObject(any<HeadObjectRequest>()) } returns
+            CompletableFuture.failedFuture(s3Error(500, "Internal Server Error"))
+
+        StepVerifier.create(storage.metadata("some-key")).expectError(S3Exception::class.java).verify()
+    }
+
+    @Test
+    fun `metadata sends correct bucket and key in request`() {
+        every { s3Client.headObject(any<HeadObjectRequest>()) } returns CompletableFuture.completedFuture(headResponse())
+
+        StepVerifier.create(storage.metadata("books/savchenko/problems/1.1.1/img.png"))
+            .expectNextCount(1)
+            .verifyComplete()
+
+        verify {
+            s3Client.headObject(
+                match<HeadObjectRequest> {
+                    it.bucket() == "test-bucket" && it.key() == "books/savchenko/problems/1.1.1/img.png"
+                }
+            )
+        }
+    }
+
+    // endregion
+
+    // region getContent()
+
+    @Test
+    fun `getContent returns byte stream on success`() {
+        val bytes = "hello".toByteArray()
+        mockGetObject(responsePublisher(getResponse(), listOf(ByteBuffer.wrap(bytes))))
+
+        StepVerifier.create(storage.getContent("some-key"))
+            .assertNext { buf ->
+                val result = ByteArray(buf.remaining())
+                buf.get(result)
+                assertThat(result).isEqualTo(bytes)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `getContent streams multiple chunks in order`() {
+        val chunk1 = "first-".toByteArray()
+        val chunk2 = "second".toByteArray()
+        mockGetObject(responsePublisher(getResponse(), listOf(ByteBuffer.wrap(chunk1), ByteBuffer.wrap(chunk2))))
+
+        StepVerifier.create(storage.getContent("multi-chunk").map { buf -> ByteArray(buf.remaining()).also { buf.get(it) } })
+            .assertNext { assertThat(it).isEqualTo(chunk1) }
+            .assertNext { assertThat(it).isEqualTo(chunk2) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `getContent returns empty flux on 404`() {
+        mockGetObjectError(s3Error(404))
+
+        StepVerifier.create(storage.getContent("missing-key")).verifyComplete()
+    }
+
+    @Test
+    fun `getContent propagates non-404 S3 errors`() {
+        mockGetObjectError(s3Error(500))
+
+        StepVerifier.create(storage.getContent("some-key")).expectError(S3Exception::class.java).verify()
+    }
+
+    // endregion
+
+    // region getContentWithMetadata()
+
+    @Test
+    fun `getContentWithMetadata returns content and metadata from single call`() {
+        val bytes = "image-data".toByteArray()
+        mockGetObject(responsePublisher(getResponse("image/jpeg"), listOf(ByteBuffer.wrap(bytes))))
+
+        StepVerifier.create(storage.getContentWithMetadata("some-key"))
+            .assertNext { cwm ->
+                assertThat(cwm.metadata).isEqualTo("image/jpeg")
+                val result =
+                    cwm.content.collectList().block()!!.let { bufs ->
+                        ByteArray(bufs.sumOf { it.remaining() }).also { out ->
+                            var pos = 0
+                            bufs.forEach { buf ->
+                                val chunk = ByteArray(buf.remaining())
+                                buf.get(chunk)
+                                chunk.copyInto(out, pos)
+                                pos += chunk.size
+                            }
+                        }
+                    }
+                assertThat(result).isEqualTo(bytes)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `getContentWithMetadata streams multiple chunks`() {
+        val chunk1 = ByteBuffer.wrap("AAA".toByteArray())
+        val chunk2 = ByteBuffer.wrap("BBB".toByteArray())
+        mockGetObject(responsePublisher(getResponse("text/plain"), listOf(chunk1, chunk2)))
+
+        StepVerifier.create(storage.getContentWithMetadata("multi"))
+            .assertNext { cwm ->
+                assertThat(cwm.metadata).isEqualTo("text/plain")
+                val count = cwm.content.count().block()!!
+                assertThat(count).isEqualTo(2)
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `getContentWithMetadata returns empty on 404`() {
+        mockGetObjectError(s3Error(404))
+
+        StepVerifier.create(storage.getContentWithMetadata("missing-key")).verifyComplete()
+    }
+
+    @Test
+    fun `getContentWithMetadata propagates non-404 S3 errors`() {
+        mockGetObjectError(s3Error(503, "Service Unavailable"))
+
+        StepVerifier.create(storage.getContentWithMetadata("some-key")).expectError(S3Exception::class.java).verify()
+    }
+
+    // endregion
+
+    // region generatePresignedUrl()
+
+    @Test
+    fun `generatePresignedUrl returns url from presigner`() {
+        val presigned = mockk<PresignedGetObjectRequest>()
+        every { presigned.url() } returns URI.create("https://s3.example.com/test-bucket/key?signed=1").toURL()
+        every { s3Presigner.presignGetObject(any<GetObjectPresignRequest>()) } returns presigned
+
+        StepVerifier.create(storage.generatePresignedUrl("key"))
+            .assertNext { assertThat(it).isEqualTo("https://s3.example.com/test-bucket/key?signed=1") }
+            .verifyComplete()
+    }
+
+    // endregion
+
+    // region prefixed()
+
+    @Test
+    fun `prefixed lists objects and maps keys via buildKey`() {
+        every { s3Client.listObjectsV2Paginator(any<ListObjectsV2Request>()) } returns
+            listPublisher("books/savchenko/problems/1.1.1/img1.png", "books/savchenko/problems/1.1.1/img2.png")
+
+        StepVerifier.create(storage.prefixed("books/savchenko/problems/1.1.1/"))
+            .assertNext { assertThat(it).isEqualTo("books/savchenko/problems/1.1.1/img1.png") }
+            .assertNext { assertThat(it).isEqualTo("books/savchenko/problems/1.1.1/img2.png") }
+            .verifyComplete()
+
+        verify {
+            s3Client.listObjectsV2Paginator(
+                match<ListObjectsV2Request> {
+                    it.bucket() == "test-bucket" && it.prefix() == "books/savchenko/problems/1.1.1/"
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `prefixed returns empty flux when no objects match`() {
+        every { s3Client.listObjectsV2Paginator(any<ListObjectsV2Request>()) } returns listPublisher()
+
+        StepVerifier.create(storage.prefixed("nonexistent/")).verifyComplete()
+    }
+
+    // endregion
+
+    // region upload()
+
+    @Test
+    fun `upload delegates to putObject and returns key`() {
+        every { s3Client.putObject(any<PutObjectRequest>(), any<AsyncRequestBody>()) } returns
+            CompletableFuture.completedFuture(PutObjectResponse.builder().build())
+
+        val content = Flux.just(ByteBuffer.wrap("data".toByteArray()))
+
+        StepVerifier.create(storage.upload("my-key", 4L, "text/plain", content)).expectNext("my-key").verifyComplete()
+
+        verify {
+            s3Client.putObject(
+                match<PutObjectRequest> {
+                    it.bucket() == "test-bucket" &&
+                        it.key() == "my-key" &&
+                        it.contentType() == "text/plain" &&
+                        it.contentLength() == 4L
+                },
+                any<AsyncRequestBody>(),
+            )
+        }
+    }
+
+    @Test
+    fun `upload convenience overload collects content and computes size`() {
+        every { s3Client.putObject(any<PutObjectRequest>(), any<AsyncRequestBody>()) } returns
+            CompletableFuture.completedFuture(PutObjectResponse.builder().build())
+
+        val content = Flux.just(ByteBuffer.wrap("abc".toByteArray()), ByteBuffer.wrap("de".toByteArray()))
+
+        StepVerifier.create(storage.upload("auto-size", "text/plain", content)).expectNext("auto-size").verifyComplete()
+
+        verify { s3Client.putObject(match<PutObjectRequest> { it.contentLength() == 5L }, any<AsyncRequestBody>()) }
+    }
+
+    // endregion
+
+    // region delete()
+
+    @Test
+    fun `delete returns true on success`() {
+        mockDeleteSuccess()
+
+        StepVerifier.create(storage.delete("some-key")).expectNext(true).verifyComplete()
+    }
+
+    @Test
+    fun `delete returns false on error`() {
+        every { s3Client.deleteObject(any<DeleteObjectRequest>()) } returns
+            CompletableFuture.failedFuture(RuntimeException("connection refused"))
+
+        StepVerifier.create(storage.delete("some-key")).expectNext(false).verifyComplete()
+    }
+
+    // endregion
+
+    // region deleteAll()
+
+    @Test
+    fun `deleteAll sends batch request and returns true on success`() {
+        val response = mockk<DeleteObjectsResponse>()
+        every { response.hasErrors() } returns false
+        every { s3Client.deleteObjects(any<DeleteObjectsRequest>()) } returns CompletableFuture.completedFuture(response)
+
+        StepVerifier.create(storage.deleteAll(listOf("key1", "key2", "key3"))).expectNext(true).verifyComplete()
+
+        verify {
+            s3Client.deleteObjects(
+                match<DeleteObjectsRequest> {
+                    it.delete().objects().map { obj -> obj.key() } == listOf("key1", "key2", "key3")
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `deleteAll returns false when response has errors`() {
+        val response = mockk<DeleteObjectsResponse>()
+        every { response.hasErrors() } returns true
+        every { s3Client.deleteObjects(any<DeleteObjectsRequest>()) } returns CompletableFuture.completedFuture(response)
+
+        StepVerifier.create(storage.deleteAll(listOf("key1"))).expectNext(false).verifyComplete()
+    }
+
+    // endregion
+
+    // region move()
+
+    @Test
+    fun `move copies then deletes source`() {
+        every { s3Client.copyObject(any<CopyObjectRequest>()) } returns
+            CompletableFuture.completedFuture(CopyObjectResponse.builder().build())
+        mockDeleteSuccess()
+
+        StepVerifier.create(storage.move("source", "target")).expectNext(true).verifyComplete()
+
+        verify {
+            s3Client.copyObject(match<CopyObjectRequest> { it.sourceKey() == "source" && it.destinationKey() == "target" })
+        }
+        verify { s3Client.deleteObject(match<DeleteObjectRequest> { it.key() == "source" }) }
+    }
+
+    @Test
+    fun `move does not delete source when copy fails`() {
+        every { s3Client.copyObject(any<CopyObjectRequest>()) } returns
+            CompletableFuture.failedFuture(s3Error(500, "copy failed"))
+
+        StepVerifier.create(storage.move("source", "target")).expectError(S3Exception::class.java).verify()
+
+        verify(exactly = 0) { s3Client.deleteObject(any<DeleteObjectRequest>()) }
+    }
+
+    // endregion
+}

--- a/gradle/plugins/src/main/kotlin/io/github/sanyavertolet/edukate/buildutils/kotlin-quality-configuration.gradle.kts
+++ b/gradle/plugins/src/main/kotlin/io/github/sanyavertolet/edukate/buildutils/kotlin-quality-configuration.gradle.kts
@@ -53,4 +53,9 @@ tasks.named<JacocoReport>("jacocoTestReport") {
         xml.required.set(true)
         html.required.set(true)
     }
+    classDirectories.setFrom(
+        classDirectories.files.map { dir ->
+            fileTree(dir) { exclude("**/configs/**") }
+        }
+    )
 }


### PR DESCRIPTION
### What's done:

  - Add getContentWithMetadata() to the storage interface — single S3 GET returns both content stream and metadata, eliminating redundant HEAD calls in MediaContentResolver and FileManager.uploadFile
  - Add 19 unit tests for AbstractReadOnlyStorage and AbstractStorage core classes, bringing edukate-storage line coverage from 39% to 97.5%
  - Exclude **/configs/** from JaCoCo coverage reports (Spring wiring boilerplate)
  - Fix public problem set access: add missing /api/v1/problem-sets/* to PublicEndpoints, remove AuthRequired wrapper from the problem set detail route, fix stale /api/v1/bundles/public reference
  - Reorder problem set tabs to Public | Joined | Owned, default to Public for all users
  - MUI theme polishing: add MuiLinearProgress component override, replace hardcoded padding and shadows in Styled.ts with theme tokens
  - Fix footer text color not updating on theme switch
  - Move book filter chip from the filter row to a dedicated line between toolbar and table