### PR TITLE
Mobile-first responsive redesign and PWA support

### DIFF
--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/dtos/ProblemMetadata.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/dtos/ProblemMetadata.kt
@@ -1,6 +1,7 @@
 package io.github.sanyavertolet.edukate.backend.dtos
 
 import io.github.sanyavertolet.edukate.backend.entities.Problem
+import java.time.Instant
 
 data class ProblemMetadata(
     val key: String,
@@ -9,4 +10,5 @@ data class ProblemMetadata(
     val isHard: Boolean,
     val tags: List<String>,
     val status: Problem.Status,
+    val createdAt: Instant,
 )

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/entities/Problem.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/entities/Problem.kt
@@ -1,5 +1,6 @@
 package io.github.sanyavertolet.edukate.backend.entities
 
+import java.time.Instant
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 
@@ -14,6 +15,7 @@ data class Problem(
     val text: String,
     val subtasks: List<Subtask> = emptyList(),
     val images: List<String> = emptyList(),
+    val createdAt: Instant = Instant.now(),
 ) {
     data class Subtask(val id: String, val text: String)
 

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapper.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapper.kt
@@ -60,6 +60,7 @@ class ProblemMapper(
                     isHard = problem.isHard,
                     tags = problem.tags,
                     status = tuple.t1,
+                    createdAt = problem.createdAt,
                 )
             }
     }

--- a/edukate-backend/src/main/resources/db/dev/V22042026__dev_data.sql
+++ b/edukate-backend/src/main/resources/db/dev/V22042026__dev_data.sql
@@ -61,29 +61,31 @@ ON CONFLICT (slug) DO NOTHING;
 -- Insertion order determines problem IDs (see MinIO table above).
 
 -- Ch.1 Kinematics — 1.3.13 (hard, projectile motion envelope)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '1.3.13', 'savchenko/1.3.13', true,
     '["Движение в поле тяжести. Криволинейное движение"]',
     'Снаряд, вылетев из орудия, попал в точку с координатами $x$ по горизонтали и $y$ по вертикали. Начальная скорость снаряда $v$. Найдите: а) тангенс угла, образуемого стволом орудия с горизонтом; б) границу области возможного попадания снаряда; в) наименьшую начальную скорость снаряда, при которой он может попасть в точку с координатами $x$, $y$. *Указание.* При решении воспользуйтесь тождеством $1/\cos^{2}\varphi = \mathrm{tg}^{2}\varphi + 1$.',
     '[]',
-    '[]'
+    '[]',
+    '2025-06-01T10:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.2 Dynamics — 2.4.34 (energy, inelastic collision; has image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '2.4.34', 'savchenko/2.4.34', false,
     '["Энергия системы. Передача энергии. Мощность"]',
     'Два груза массы $m_{1}$ и $m_{2}$ ($m_{1} > m_{2}$) связаны нитью, переброшенной через неподвижный блок. В начальный момент груз массы $m_{1}$ удерживают на высоте $h$ над полом. Затем его без толчка отпускают. Какое количество теплоты выделится при ударе груза о пол? Удар абсолютно неупругий.',
     '[]',
-    '["2.4.34.jpg"]'
+    '["2.4.34.jpg"]',
+    '2025-07-15T14:30:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.2 Dynamics — 2.1.30 (hard, Newton laws; 2 subtasks + image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '2.1.30', 'savchenko/2.1.30', true,
@@ -91,11 +93,12 @@ VALUES (
     '',
     '[{"id": "а", "text": "Какую силу надо приложить к телу, чтобы тело соскользнуло с неё? За какое время тело соскользнёт, если к доске приложена сила $F_{0}$, а длина доски равна $l$?"},
       {"id": "б", "text": "С каким ускорением движутся тело и доска, если сила $F_{0}$ действует на тело массы $m_{1}$? (Тело массы $m_{1}$ лежит на доске массы $m_{2}$, находящейся на гладкой горизонтальной плоскости. Коэффициент трения между телом и доской $\\mu$.)"}]',
-    '["2.1.30.jpg"]'
+    '["2.1.30.jpg"]',
+    '2025-07-15T14:45:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.3 Oscillations and Waves — 3.2.7 (pendulum with magnet; 2 subtasks + problem & answer image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '3.2.7', 'savchenko/3.2.7', false,
@@ -103,33 +106,36 @@ VALUES (
     '',
     '[{"id": "а", "text": "Математический маятник — железный шарик массы $m$, висящий на длинной нити, — имеет период $T_{0}$. В присутствии магнита, расположенного чуть ниже шарика, период колебаний стал равным $T$. Определите действующую на шарик магнитную силу."},
       {"id": "б", "text": "Железный шарик маятника поместили между полюсами магнита так, что на него действует горизонтальная магнитная сила. Найдите эту силу и новое положение равновесия шарика, если период его колебаний после включения магнитного поля стал равным $T$."}]',
-    '["3.2.7.jpg"]'
+    '["3.2.7.jpg"]',
+    '2025-08-20T09:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.4 Fluid Mechanics — 4.3.12 (hard, triangular notch outflow; has image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '4.3.12', 'savchenko/4.3.12', true,
     '["Движение идеальной жидкости"]',
     'Вода вытекает из широкого сосуда через треугольный вырез в его стенке. Во сколько раз уменьшится скорость понижения уровня воды при изменении высоты её уровня от $H$ до $h$?',
     '[]',
-    '["4.3.12.jpg"]'
+    '["4.3.12.jpg"]',
+    '2025-09-10T11:15:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.5 Molecular Physics — 5.6.19 (adiabatic piston compression; has image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '5.6.19', 'savchenko/5.6.19', false,
     '["Первое начало термодинамики. Теплоёмкость"]',
     'Поршень массы $M$, закрывающий объём $V_{0}$ одноатомного газа при давлении $P_{0}$ и температуре $T_{0}$, движется со скоростью $u$. Определите температуру и объём газа при максимальном сжатии. Система теплоизолирована, теплоёмкостями поршня и сосуда пренебречь.',
     '[]',
-    '["5.6.19.jpg"]'
+    '["5.6.19.jpg"]',
+    '2025-10-05T16:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.6 Electrostatics — 6.4.2 (parallel-plate capacitor; 2 subtasks)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '6.4.2', 'savchenko/6.4.2', false,
@@ -137,55 +143,60 @@ VALUES (
     '',
     '[{"id": "а", "text": "Размеры пластин плоского конденсатора увеличили в два раза. Как изменилась ёмкость конденсатора?"},
       {"id": "б", "text": "Как изменится ёмкость плоского конденсатора, если расстояние между пластинами удвоить? Увеличить в $n$ раз?"}]',
-    '[]'
+    '[]',
+    '2025-11-12T08:30:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.7 Charged Particle Motion — 7.4.10 (hard, charged particles near metallic dihedral; problem & answer image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '7.4.10', 'savchenko/7.4.10', true,
     '["Взаимодействие заряженных частиц"]',
     'Скорости трёх заряженных частиц массы $m$ изображены на рисунке. Расстояние от каждой частицы до ребра металлического двугранного угла $d$. Заряды первых двух частиц, летящих в противоположных направлениях, равны $\pm q$. Найдите скорость третьей нейтральной частицы на бесконечности, если начальная скорость этой частицы равна $v$.',
     '[]',
-    '["7.4.10.jpg"]'
+    '["7.4.10.jpg"]',
+    '2025-12-01T13:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.8 Electric Current — 8.3.8 (voltmeter range switching paradox)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '8.3.8', 'savchenko/8.3.8', false,
     '["Электрические цепи"]',
     'Переключая вольтметр на измерение вдвое большего диапазона напряжения (со $100$ на $200$ В), ожидали отклонения стрелки на вдвое меньшее число делений. Однако этого не произошло, хотя в остальной части цепи ничего не изменяли. Большее или меньшее напряжение покажет вольтметр после переключения?',
     '[]',
-    '[]'
+    '[]',
+    '2026-01-08T10:45:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.9 Magnetic Field — 9.2.23 (magnetised plates, magnetic moment estimate)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '9.2.23', 'savchenko/9.2.23', false,
     '["Магнитное поле движущегося заряда. Индукция магнитного поля линейного тока"]',
     'Сила взаимодействия двух тонких намагниченных квадратных пластин, расположенных на расстоянии $H$ друг над другом, равна $F$. Размеры пластин $a \times a \times h$. Оцените магнитный момент единицы объёма пластины, если толщина пластины $h \ll H$, а $H \ll a$.',
     '[]',
-    '[]'
+    '[]',
+    '2026-02-14T15:20:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.10 Charged Particles — 10.1.21 (charged ring in axial magnetic field; has image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '10.1.21', 'savchenko/10.1.21', false,
     '["Движение в однородном магнитном поле"]',
     'Равномерно заряженное кольцо радиуса $R$, линейная плотность заряда которого $\rho$, движется соосно аксиально-симметричному магнитному полю со скоростью $v$. Радиальная составляющая индукции магнитного поля на расстоянии $R$ от оси равна $B_{R}$. Определите момент сил, действующих на кольцо.',
     '[]',
-    '["10.1.21.jpg"]'
+    '["10.1.21.jpg"]',
+    '2026-03-01T12:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.11 Electromagnetic Induction — 11.3.19 (hard, transformer short-circuit; 2 subtasks)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '11.3.19', 'savchenko/11.3.19', true,
@@ -193,11 +204,12 @@ VALUES (
     '',
     '[{"id": "а", "text": "Почему опасно замыкание хотя бы одного витка вторичной обмотки трансформатора?"},
       {"id": "б", "text": "Замыкание витка вторичной обмотки трансформатора приводит иногда к выходу из строя первичной обмотки трансформатора. Почему это происходит?"}]',
-    '[]'
+    '[]',
+    '2026-03-18T09:30:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.12 Electromagnetic Waves — 12.1.25 (reflection law proof; 2 subtasks + image)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '12.1.25', 'savchenko/12.1.25', false,
@@ -205,29 +217,32 @@ VALUES (
     'Пользуясь методом, изложенным в задаче 12.1.19, докажите, что угол падения электромагнитной волны равен углу отражения. Рассмотрите случаи:',
     '[{"id": "а", "text": "вектор $E$ электромагнитной волны, падающей на металл, параллелен металлической поверхности;"},
       {"id": "б", "text": "вектор $B$ электромагнитной волны параллелен металлической поверхности."}]',
-    '["12.1.25.jpg"]'
+    '["12.1.25.jpg"]',
+    '2026-04-02T17:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.13 Optics — 13.3.10 (Moon photography defocus correction)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '13.3.10', 'savchenko/13.3.10', false,
     '["Оптические системы"]',
     'При фотографировании Луны получено размытое изображение в виде диска радиуса $r_{1}$. Резкое изображение Луны имело бы радиус $r_{2}$. Определите, на какое расстояние нужно сместить фотопластинку, чтобы изображение на ней получилось резким. Фокусное расстояние линзы $f$, диаметр $D$, при этом $r_{2} > D/2 > r_{1}$.',
     '[]',
-    '[]'
+    '[]',
+    '2026-04-10T11:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- Ch.14 Special Relativity — 14.3.19 (relativistic electron beam density)
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '14.3.19', 'savchenko/14.3.19', false,
     '["Преобразование электрического и магнитного полей"]',
     'Скорость электронов в параллельном пучке $\beta c$. Как изменится плотность электронов при движении относительно пучка со скоростью $\beta_{1}c$ в продольном направлении?',
     '[]',
-    '[]'
+    '[]',
+    '2026-04-20T14:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- ── Answers ───────────────────────────────────────────────────────────────────
@@ -302,14 +317,15 @@ INSERT INTO answers (problem_id, text, notes, images) VALUES
 ON CONFLICT (problem_id) DO NOTHING;
 
 -- Ch.1 Kinematics — 1.1.4 (pion decay, speed of light; has image) — added for submission testing
-INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images)
+INSERT INTO problems (book_id, code, key, is_hard, tags, text, subtasks, images, created_at)
 VALUES (
     (SELECT id FROM books WHERE slug = 'savchenko'),
     '1.1.4', 'savchenko/1.1.4', false,
     '["Движение с постоянной скоростью"]',
     'Счетчики $A$ и $B$, регистрирующие момент прихода $\gamma$-кванта, расположены на расстоянии $2$ м друг от друга. В некоторой точке между ними произошел распад $\pi^{0}$-мезона на два $\gamma$-кванта. Найдите положение этой точки, если счетчик $A$ зарегистрировал $\gamma$-квант на $10^{-9}$ с позднее, чем счетчик $B$. Скорость света $3 \cdot 10^{8}$ м/с.',
     '[]',
-    '["1.1.4.jpg"]'
+    '["1.1.4.jpg"]',
+    '2026-04-25T08:00:00Z'
 ) ON CONFLICT (key) DO NOTHING;
 
 -- 11.3.19 — no answer in source data, intentionally omitted.

--- a/edukate-backend/src/main/resources/db/migration/V1__create_schema.sql
+++ b/edukate-backend/src/main/resources/db/migration/V1__create_schema.sql
@@ -26,6 +26,7 @@ CREATE TABLE problems (
     text        TEXT NOT NULL,
     subtasks    JSONB NOT NULL DEFAULT '[]',
     images      JSONB NOT NULL DEFAULT '[]',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     UNIQUE (book_id, code),
     UNIQUE (code)
 );

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/BackendFixtures.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/BackendFixtures.kt
@@ -125,6 +125,7 @@ object BackendFixtures {
         text: String = "Test problem text",
         subtasks: List<Problem.Subtask> = emptyList(),
         images: List<String> = emptyList(),
+        createdAt: Instant = Instant.parse("2025-06-01T10:00:00Z"),
     ) =
         Problem(
             id = id,
@@ -136,6 +137,7 @@ object BackendFixtures {
             text = text,
             subtasks = subtasks,
             images = images,
+            createdAt = createdAt,
         )
 
     fun problemProgress(

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemControllerTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/controllers/ProblemControllerTest.kt
@@ -12,6 +12,7 @@ import io.github.sanyavertolet.edukate.backend.mappers.ProblemMapper
 import io.github.sanyavertolet.edukate.backend.services.ProblemService
 import io.github.sanyavertolet.edukate.common.security.NoopWebSecurityConfig
 import io.mockk.every
+import java.time.Instant
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.webflux.test.autoconfigure.WebFluxTest
@@ -33,7 +34,7 @@ class ProblemControllerTest {
     @MockkBean private lateinit var problemMapper: ProblemMapper
 
     private fun metadata(code: String = "1.1.1") =
-        ProblemMetadata("savchenko/$code", code, "savchenko", false, emptyList(), Problem.Status.NOT_SOLVED)
+        ProblemMetadata("savchenko/$code", code, "savchenko", false, emptyList(), Problem.Status.NOT_SOLVED, Instant.now())
 
     private fun dto(code: String = "1.1.1") =
         ProblemDto(

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapperTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/mappers/ProblemMapperTest.kt
@@ -3,6 +3,7 @@
 package io.github.sanyavertolet.edukate.backend.mappers
 
 import io.github.sanyavertolet.edukate.backend.BackendFixtures
+import io.github.sanyavertolet.edukate.backend.entities.Book
 import io.github.sanyavertolet.edukate.backend.entities.Problem
 import io.github.sanyavertolet.edukate.backend.services.AnswerService
 import io.github.sanyavertolet.edukate.backend.services.BookService
@@ -11,6 +12,7 @@ import io.github.sanyavertolet.edukate.backend.services.files.FileManager
 import io.github.sanyavertolet.edukate.storage.keys.ProblemFileKey
 import io.mockk.every
 import io.mockk.mockk
+import java.time.Instant
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -56,6 +58,45 @@ class ProblemMapperTest {
 
         StepVerifier.create(mapper.toMetadata(problem, auth))
             .assertNext { meta -> assertThat(meta.status).isEqualTo(Problem.Status.SOLVING) }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `toMetadata propagates createdAt from entity`() {
+        val auth = BackendFixtures.mockAuthentication()
+        val timestamp = Instant.parse("2026-03-15T12:00:00Z")
+        val problem = BackendFixtures.problem(id = 1L, code = "2.1.1", createdAt = timestamp)
+        every { problemStatusDecisionManager.getStatus(1L, auth) } returns Mono.just(Problem.Status.NOT_SOLVED)
+        every { bookService.findById(any()) } returns Mono.just(BackendFixtures.book())
+
+        StepVerifier.create(mapper.toMetadata(problem, auth))
+            .assertNext { meta ->
+                assertThat(meta.createdAt).isEqualTo(timestamp)
+                assertThat(meta.code).isEqualTo("2.1.1")
+            }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `toMetadata resolves bookSlug from book service`() {
+        val auth = BackendFixtures.mockAuthentication()
+        val problem = BackendFixtures.problem(id = 1L, bookId = 5L)
+        every { problemStatusDecisionManager.getStatus(1L, auth) } returns Mono.just(Problem.Status.NOT_SOLVED)
+        every { bookService.findById(5L) } returns Mono.just(BackendFixtures.book(id = 5L, slug = "irodov"))
+
+        StepVerifier.create(mapper.toMetadata(problem, auth))
+            .assertNext { meta -> assertThat(meta.bookSlug).isEqualTo("irodov") }
+            .verifyComplete()
+    }
+
+    @Test
+    fun `toMetadata defaults bookSlug to unknown when book is missing`() {
+        val problem = BackendFixtures.problem(id = 1L, bookId = 999L)
+        every { problemStatusDecisionManager.getStatus(1L, null) } returns Mono.just(Problem.Status.NOT_SOLVED)
+        every { bookService.findById(999L) } returns Mono.empty<Book>()
+
+        StepVerifier.create(mapper.toMetadata(problem, null))
+            .assertNext { meta -> assertThat(meta.bookSlug).isEqualTo("unknown") }
             .verifyComplete()
     }
 }

--- a/edukate-frontend/index.html
+++ b/edukate-frontend/index.html
@@ -2,11 +2,16 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <meta name="theme-color" content="#851691" />
+        <meta name="description" content="Physics problem-solving platform" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+        <meta name="apple-mobile-web-app-title" content="Edukate" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
         <link rel="manifest" href="/site.webmanifest" />
-        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Edukate</title>
     </head>
     <body>

--- a/edukate-frontend/nginx.conf
+++ b/edukate-frontend/nginx.conf
@@ -29,6 +29,21 @@ server {
         deny all;
     }
 
+    # Service worker — never cache (browser must byte-compare to detect updates)
+    location = /sw.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    # Web manifest — never cache (changes must propagate quickly)
+    location = /site.webmanifest {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    # Workbox runtime files — cache forever (content-hashed by Workbox)
+    location ~* /workbox-.*\.js$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
     # Hashed JS/CSS chunks — cache forever (content-addressed by Vite)
     location ~* \.(js|css)$ {
         add_header Cache-Control "public, max-age=31536000, immutable";

--- a/edukate-frontend/package-lock.json
+++ b/edukate-frontend/package-lock.json
@@ -50,6 +50,7 @@
                 "typescript": "~5.7.2",
                 "typescript-eslint": "^8.22.0",
                 "vite": "^6.1.0",
+                "vite-plugin-pwa": "^1.2.0",
                 "vitest": "^4.1.3"
             }
         },
@@ -189,6 +190,19 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-annotate-as-pure": {
+            "version": "7.27.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+            "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.27.3"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
@@ -206,11 +220,82 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@babel/helper-create-class-features-plugin": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+            "integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.28.6",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/traverse": "^7.28.6",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-create-regexp-features-plugin": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.28.5.tgz",
+            "integrity": "sha512-N1EhvLtHzOvj7QQOUCCS3NrPJP8c5W6ZXCHDn7Yialuy1iu4r5EmIYkXlKNqT99Ciw+W0mDqWoR6HWMZlFP3hw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "regexpu-core": "^6.3.1",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-define-polyfill-provider": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+            "integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "debug": "^4.4.3",
+                "lodash.debounce": "^4.0.8",
+                "resolve": "^1.22.11"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
         "node_modules/@babel/helper-globals": {
             "version": "7.28.0",
             "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-member-expression-to-functions": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
+            "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.28.5",
+                "@babel/types": "^7.28.5"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -246,12 +331,75 @@
                 "@babel/core": "^7.0.0"
             }
         },
+        "node_modules/@babel/helper-optimise-call-expression": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+            "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/types": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.28.6",
             "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
             "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-remap-async-to-generator": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+            "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.1",
+                "@babel/helper-wrap-function": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-replace-supers": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+            "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-member-expression-to-functions": "^7.28.5",
+                "@babel/helper-optimise-call-expression": "^7.27.1",
+                "@babel/traverse": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+            "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -280,6 +428,21 @@
             "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@babel/helper-wrap-function": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+            "integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
+            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -313,6 +476,811 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.28.5.tgz",
+            "integrity": "sha512-87GDMS3tsmMSi/3bWOte1UblL+YUTFMV8SZPZ2eSEL17s74Cw/l63rR6NmGVKMYW2GYi85nE+/d6Hw5N0bEk2Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+            "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+            "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+            "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
+                "@babel/plugin-transform-optional-chaining": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.13.0"
+            }
+        },
+        "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+            "integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/traverse": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-proposal-private-property-in-object": {
+            "version": "7.21.0-placeholder-for-preset-env.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+            "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-import-assertions": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+            "integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-import-attributes": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+            "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
+            "version": "7.18.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+            "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+                "@babel/helper-plugin-utils": "^7.18.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-arrow-functions": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+            "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-async-generator-functions": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+            "integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-remap-async-to-generator": "^7.27.1",
+                "@babel/traverse": "^7.29.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-async-to-generator": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+            "integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-remap-async-to-generator": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-block-scoped-functions": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+            "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-block-scoping": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+            "integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-class-properties": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+            "integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-class-static-block": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+            "integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.12.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-classes": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+            "integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-globals": "^7.28.0",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-replace-supers": "^7.28.6",
+                "@babel/traverse": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-computed-properties": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+            "integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/template": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-destructuring": {
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.5.tgz",
+            "integrity": "sha512-Kl9Bc6D0zTUcFUvkNuQh4eGXPKKNDOJQXVyyM4ZAQPMveniJdxi8XMJwLo+xSoW3MIq81bD33lcUe9kZpl0MCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-dotall-regex": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+            "integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-duplicate-keys": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+            "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-dynamic-import": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+            "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-explicit-resource-management": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+            "integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-exponentiation-operator": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+            "integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-export-namespace-from": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+            "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-for-of": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+            "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-function-name": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+            "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-json-strings": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+            "integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-literals": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+            "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-logical-assignment-operators": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+            "integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-member-expression-literals": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+            "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-modules-amd": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+            "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-modules-commonjs": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+            "integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-modules-systemjs": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+            "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.29.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-modules-umd": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+            "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+            "integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-new-target": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+            "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+            "integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-numeric-separator": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+            "integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-object-rest-spread": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+            "integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5",
+                "@babel/plugin-transform-parameters": "^7.27.7",
+                "@babel/traverse": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-object-super": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+            "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1",
+                "@babel/helper-replace-supers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-optional-catch-binding": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+            "integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-optional-chaining": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+            "integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-parameters": {
+            "version": "7.27.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+            "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-private-methods": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+            "integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-private-property-in-object": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+            "integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-annotate-as-pure": "^7.27.3",
+                "@babel/helper-create-class-features-plugin": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-property-literals": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+            "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-transform-react-jsx-self": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
@@ -343,6 +1311,303 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-regenerator": {
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+            "integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-regexp-modifiers": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+            "integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-reserved-words": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+            "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-shorthand-properties": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+            "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-spread": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+            "integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-sticky-regex": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+            "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-template-literals": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+            "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-typeof-symbol": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+            "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-unicode-escapes": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+            "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-unicode-property-regex": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+            "integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-unicode-regex": {
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+            "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.27.1",
+                "@babel/helper-plugin-utils": "^7.27.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/plugin-transform-unicode-sets-regex": {
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+            "integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-create-regexp-features-plugin": "^7.28.5",
+                "@babel/helper-plugin-utils": "^7.28.6"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0"
+            }
+        },
+        "node_modules/@babel/preset-env": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+            "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.29.0",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-plugin-utils": "^7.28.6",
+                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
+                "@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+                "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+                "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+                "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
+                "@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+                "@babel/plugin-syntax-import-assertions": "^7.28.6",
+                "@babel/plugin-syntax-import-attributes": "^7.28.6",
+                "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+                "@babel/plugin-transform-arrow-functions": "^7.27.1",
+                "@babel/plugin-transform-async-generator-functions": "^7.29.0",
+                "@babel/plugin-transform-async-to-generator": "^7.28.6",
+                "@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+                "@babel/plugin-transform-block-scoping": "^7.28.6",
+                "@babel/plugin-transform-class-properties": "^7.28.6",
+                "@babel/plugin-transform-class-static-block": "^7.28.6",
+                "@babel/plugin-transform-classes": "^7.28.6",
+                "@babel/plugin-transform-computed-properties": "^7.28.6",
+                "@babel/plugin-transform-destructuring": "^7.28.5",
+                "@babel/plugin-transform-dotall-regex": "^7.28.6",
+                "@babel/plugin-transform-duplicate-keys": "^7.27.1",
+                "@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
+                "@babel/plugin-transform-dynamic-import": "^7.27.1",
+                "@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+                "@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+                "@babel/plugin-transform-export-namespace-from": "^7.27.1",
+                "@babel/plugin-transform-for-of": "^7.27.1",
+                "@babel/plugin-transform-function-name": "^7.27.1",
+                "@babel/plugin-transform-json-strings": "^7.28.6",
+                "@babel/plugin-transform-literals": "^7.27.1",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
+                "@babel/plugin-transform-member-expression-literals": "^7.27.1",
+                "@babel/plugin-transform-modules-amd": "^7.27.1",
+                "@babel/plugin-transform-modules-commonjs": "^7.28.6",
+                "@babel/plugin-transform-modules-systemjs": "^7.29.0",
+                "@babel/plugin-transform-modules-umd": "^7.27.1",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
+                "@babel/plugin-transform-new-target": "^7.27.1",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+                "@babel/plugin-transform-numeric-separator": "^7.28.6",
+                "@babel/plugin-transform-object-rest-spread": "^7.28.6",
+                "@babel/plugin-transform-object-super": "^7.27.1",
+                "@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+                "@babel/plugin-transform-optional-chaining": "^7.28.6",
+                "@babel/plugin-transform-parameters": "^7.27.7",
+                "@babel/plugin-transform-private-methods": "^7.28.6",
+                "@babel/plugin-transform-private-property-in-object": "^7.28.6",
+                "@babel/plugin-transform-property-literals": "^7.27.1",
+                "@babel/plugin-transform-regenerator": "^7.29.0",
+                "@babel/plugin-transform-regexp-modifiers": "^7.28.6",
+                "@babel/plugin-transform-reserved-words": "^7.27.1",
+                "@babel/plugin-transform-shorthand-properties": "^7.27.1",
+                "@babel/plugin-transform-spread": "^7.28.6",
+                "@babel/plugin-transform-sticky-regex": "^7.27.1",
+                "@babel/plugin-transform-template-literals": "^7.27.1",
+                "@babel/plugin-transform-typeof-symbol": "^7.27.1",
+                "@babel/plugin-transform-unicode-escapes": "^7.27.1",
+                "@babel/plugin-transform-unicode-property-regex": "^7.28.6",
+                "@babel/plugin-transform-unicode-regex": "^7.27.1",
+                "@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
+                "@babel/preset-modules": "0.1.6-no-external-plugins",
+                "babel-plugin-polyfill-corejs2": "^0.4.15",
+                "babel-plugin-polyfill-corejs3": "^0.14.0",
+                "babel-plugin-polyfill-regenerator": "^0.6.6",
+                "core-js-compat": "^3.48.0",
+                "semver": "^6.3.1"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/preset-modules": {
+            "version": "0.1.6-no-external-plugins",
+            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+            "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-plugin-utils": "^7.0.0",
+                "@babel/types": "^7.4.4",
+                "esutils": "^2.0.2"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/@babel/runtime": {
@@ -1533,6 +2798,16 @@
                 }
             }
         },
+        "node_modules/@isaacs/cliui": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+            "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1561,6 +2836,17 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/@jridgewell/source-map": {
+            "version": "0.3.11",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -2276,6 +3562,97 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@rollup/plugin-node-resolve": {
+            "version": "15.3.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-15.3.1.tgz",
+            "integrity": "sha512-tgg6b91pAybXHJQMAAwW9VuWBO6Thi+q7BCNARLwSqlmsHz0XYURtGvh/AuwSADXSI4h/2uHbs7s4FzlZDGSGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "@types/resolve": "1.20.2",
+                "deepmerge": "^4.2.2",
+                "is-module": "^1.0.0",
+                "resolve": "^1.22.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.78.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/plugin-terser": {
+            "version": "0.4.4",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-terser/-/plugin-terser-0.4.4.tgz",
+            "integrity": "sha512-XHeJC5Bgvs8LfukDwWZp7yeqin6ns8RTl2B9avbejt6tZqsqvVoWI7ZTQrcNsfKEDWBTnTxM8nMDkO2IFFbd0A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "serialize-javascript": "^6.0.1",
+                "smob": "^1.0.0",
+                "terser": "^5.17.4"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.3.0.tgz",
+            "integrity": "sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "estree-walker": "^2.0.2",
+                "picomatch": "^4.0.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@rollup/pluginutils/node_modules/estree-walker": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+            "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/@rollup/rollup-android-arm-eabi": {
             "version": "4.60.2",
             "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
@@ -2872,6 +4249,29 @@
             "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@surma/rollup-plugin-off-main-thread": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@surma/rollup-plugin-off-main-thread/-/rollup-plugin-off-main-thread-2.2.3.tgz",
+            "integrity": "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "ejs": "^3.1.6",
+                "json5": "^2.2.0",
+                "magic-string": "^0.25.0",
+                "string.prototype.matchall": "^4.0.6"
+            }
+        },
+        "node_modules/@surma/rollup-plugin-off-main-thread/node_modules/magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            }
         },
         "node_modules/@tanstack/query-core": {
             "version": "5.100.1",
@@ -3616,6 +5016,13 @@
                 "@types/react": "*"
             }
         },
+        "node_modules/@types/resolve": {
+            "version": "1.20.2",
+            "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
+            "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/set-cookie-parser": {
             "version": "2.4.10",
             "resolved": "https://registry.npmjs.org/@types/set-cookie-parser/-/set-cookie-parser-2.4.10.tgz",
@@ -3630,6 +5037,13 @@
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
             "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/trusted-types": {
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+            "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4249,6 +5663,45 @@
                 "dequal": "^2.0.3"
             }
         },
+        "node_modules/array-buffer-byte-length": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+            "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "is-array-buffer": "^3.0.5"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/arraybuffer.prototype.slice": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+            "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.1",
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.5",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6",
+                "is-array-buffer": "^3.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/assertion-error": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -4278,11 +5731,54 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/async": {
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+            "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/async-function": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+            "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
+        },
+        "node_modules/at-least-node": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+            "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/available-typed-arrays": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "possible-typed-array-names": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/axios": {
             "version": "1.15.2",
@@ -4308,6 +5804,48 @@
             "engines": {
                 "node": ">=10",
                 "npm": ">=6"
+            }
+        },
+        "node_modules/babel-plugin-polyfill-corejs2": {
+            "version": "0.4.17",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+            "integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/compat-data": "^7.28.6",
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
+                "semver": "^6.3.1"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/babel-plugin-polyfill-corejs3": {
+            "version": "0.14.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+            "integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.8",
+                "core-js-compat": "^3.48.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+            }
+        },
+        "node_modules/babel-plugin-polyfill-regenerator": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+            "integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-define-polyfill-provider": "^0.6.8"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/balanced-match": {
@@ -4398,6 +5936,13 @@
                 "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
             }
         },
+        "node_modules/buffer-from": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/bundle-name": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
@@ -4414,6 +5959,25 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/call-bind": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+            "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "es-define-property": "^1.0.1",
+                "get-intrinsic": "^1.3.0",
+                "set-function-length": "^1.2.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4425,6 +5989,23 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/call-bound": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+            "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind-apply-helpers": "^1.0.2",
+                "get-intrinsic": "^1.3.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/callsites": {
@@ -4575,6 +6156,16 @@
                 "node": ">= 12"
             }
         },
+        "node_modules/common-tags": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.2.tgz",
+            "integrity": "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
         "node_modules/compare-versions": {
             "version": "6.1.1",
             "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.1.tgz",
@@ -4606,6 +6197,20 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/core-js-compat": {
+            "version": "3.49.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+            "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "browserslist": "^4.28.1"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/cosmiconfig": {
@@ -4646,6 +6251,16 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/crypto-random-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+            "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/css-tree": {
@@ -4689,6 +6304,60 @@
                 "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
+        "node_modules/data-view-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+            "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/data-view-byte-length": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+            "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/inspect-js"
+            }
+        },
+        "node_modules/data-view-byte-offset": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+            "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-data-view": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4720,6 +6389,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/deepmerge": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+            "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/default-browser": {
             "version": "5.5.0",
             "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
@@ -4750,6 +6429,24 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/define-data-property": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0",
+                "es-errors": "^1.3.0",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/define-lazy-prop": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
@@ -4761,6 +6458,24 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/define-properties": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.0.1",
+                "has-property-descriptors": "^1.0.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/delayed-stream": {
@@ -4827,6 +6542,22 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/ejs": {
+            "version": "3.1.10",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+            "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "jake": "^10.8.5"
+            },
+            "bin": {
+                "ejs": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.344",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
@@ -4875,6 +6606,75 @@
             "license": "MIT",
             "dependencies": {
                 "is-arrayish": "^0.2.1"
+            }
+        },
+        "node_modules/es-abstract": {
+            "version": "1.24.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+            "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "array-buffer-byte-length": "^1.0.2",
+                "arraybuffer.prototype.slice": "^1.0.4",
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "data-view-buffer": "^1.0.2",
+                "data-view-byte-length": "^1.0.2",
+                "data-view-byte-offset": "^1.0.1",
+                "es-define-property": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.1.1",
+                "es-set-tostringtag": "^2.1.0",
+                "es-to-primitive": "^1.3.0",
+                "function.prototype.name": "^1.1.8",
+                "get-intrinsic": "^1.3.0",
+                "get-proto": "^1.0.1",
+                "get-symbol-description": "^1.1.0",
+                "globalthis": "^1.0.4",
+                "gopd": "^1.2.0",
+                "has-property-descriptors": "^1.0.2",
+                "has-proto": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "hasown": "^2.0.2",
+                "internal-slot": "^1.1.0",
+                "is-array-buffer": "^3.0.5",
+                "is-callable": "^1.2.7",
+                "is-data-view": "^1.0.2",
+                "is-negative-zero": "^2.0.3",
+                "is-regex": "^1.2.1",
+                "is-set": "^2.0.3",
+                "is-shared-array-buffer": "^1.0.4",
+                "is-string": "^1.1.1",
+                "is-typed-array": "^1.1.15",
+                "is-weakref": "^1.1.1",
+                "math-intrinsics": "^1.1.0",
+                "object-inspect": "^1.13.4",
+                "object-keys": "^1.1.1",
+                "object.assign": "^4.1.7",
+                "own-keys": "^1.0.1",
+                "regexp.prototype.flags": "^1.5.4",
+                "safe-array-concat": "^1.1.3",
+                "safe-push-apply": "^1.0.0",
+                "safe-regex-test": "^1.1.0",
+                "set-proto": "^1.0.0",
+                "stop-iteration-iterator": "^1.1.0",
+                "string.prototype.trim": "^1.2.10",
+                "string.prototype.trimend": "^1.0.9",
+                "string.prototype.trimstart": "^1.0.8",
+                "typed-array-buffer": "^1.0.3",
+                "typed-array-byte-length": "^1.0.3",
+                "typed-array-byte-offset": "^1.0.4",
+                "typed-array-length": "^1.0.7",
+                "unbox-primitive": "^1.1.0",
+                "which-typed-array": "^1.1.19"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/es-define-property": {
@@ -4927,6 +6727,24 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/es-to-primitive": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+            "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7",
+                "is-date-object": "^1.0.5",
+                "is-symbol": "^1.0.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/esbuild": {
@@ -5351,6 +7169,39 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/filelist": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+            "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "minimatch": "^5.0.1"
+            }
+        },
+        "node_modules/filelist/node_modules/brace-expansion": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/filelist/node_modules/minimatch": {
+            "version": "5.1.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+            "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/fill-range": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5428,6 +7279,39 @@
                 }
             }
         },
+        "node_modules/for-each": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+            "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/foreground-child": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "cross-spawn": "^7.0.6",
+                "signal-exit": "^4.0.1"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/form-data": {
             "version": "4.0.5",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -5490,6 +7374,47 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/function.prototype.name": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+            "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "functions-have-names": "^1.2.3",
+                "hasown": "^2.0.2",
+                "is-callable": "^1.2.7"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/functions-have-names": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/generator-function": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5547,6 +7472,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-own-enumerable-property-symbols": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+            "integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/get-proto": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -5575,6 +7507,24 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/get-symbol-description": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+            "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/glob": {
@@ -5623,6 +7573,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/globalthis": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-properties": "^1.2.1",
+                "gopd": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/globby": {
@@ -5692,6 +7659,19 @@
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
         },
+        "node_modules/has-bigints": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+            "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -5700,6 +7680,35 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/has-property-descriptors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-define-property": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/has-proto": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+            "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/has-symbols": {
@@ -5797,6 +7806,13 @@
                 "node": ">=18.18.0"
             }
         },
+        "node_modules/idb": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+            "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5862,11 +7878,110 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/internal-slot": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+            "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "hasown": "^2.0.2",
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/is-array-buffer": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+            "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
             "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
             "license": "MIT"
+        },
+        "node_modules/is-async-function": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+            "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "async-function": "^1.0.0",
+                "call-bound": "^1.0.3",
+                "get-proto": "^1.0.1",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-bigint": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+            "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-bigints": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-boolean-object": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+            "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-callable": {
+            "version": "1.2.7",
+            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
@@ -5875,6 +7990,41 @@
             "license": "MIT",
             "dependencies": {
                 "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-data-view": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+            "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "get-intrinsic": "^1.2.6",
+                "is-typed-array": "^1.1.13"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-date-object": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+            "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-tostringtag": "^1.0.2"
             },
             "engines": {
                 "node": ">= 0.4"
@@ -5909,6 +8059,22 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-finalizationregistry": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+            "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -5917,6 +8083,26 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-generator-function": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.4",
+                "generator-function": "^2.0.0",
+                "get-proto": "^1.0.1",
+                "has-tostringtag": "^1.0.2",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-glob": {
@@ -5964,6 +8150,39 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-map": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+            "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha512-51ypPSPCoTEIN9dy5Oy+h4pShgJmPCygKfyRCISBI+JoWT/2oJvK8QPxmwv7b/p239jXrm9M1mlQbyKJ5A152g==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/is-negative-zero": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+            "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-node-process": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
@@ -5979,6 +8198,33 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
+            }
+        },
+        "node_modules/is-number-object": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+            "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-obj": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/is-path-inside": {
@@ -6014,6 +8260,64 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/is-regex": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2",
+                "hasown": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-regexp": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+            "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/is-set": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+            "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-shared-array-buffer": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+            "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-stream": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
@@ -6027,6 +8331,57 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-string": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+            "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-symbol": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+            "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "has-symbols": "^1.1.0",
+                "safe-regex-test": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-typed-array": {
+            "version": "1.1.15",
+            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/is-unicode-supported": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
@@ -6038,6 +8393,52 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/is-weakmap": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakref": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+            "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/is-weakset": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+            "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "get-intrinsic": "^1.2.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/is-wsl": {
@@ -6055,6 +8456,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/isarray": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -6100,6 +8508,40 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/jackspeak": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+            "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/cliui": "^9.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/jake": {
+            "version": "10.9.4",
+            "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+            "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "async": "^3.2.6",
+                "filelist": "^1.0.4",
+                "picocolors": "^1.1.1"
+            },
+            "bin": {
+                "jake": "bin/cli.js"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/jiti": {
@@ -6359,10 +8801,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/lodash.debounce": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.sortby": {
+            "version": "4.7.0",
+            "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+            "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
             "dev": true,
             "license": "MIT"
         },
@@ -6579,6 +9035,16 @@
                 "node": "*"
             }
         },
+        "node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -6723,6 +9189,50 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/object-inspect": {
+            "version": "1.13.4",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+            "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/object-keys": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/object.assign": {
+            "version": "4.1.7",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0",
+                "has-symbols": "^1.1.0",
+                "object-keys": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/obug": {
@@ -6955,6 +9465,24 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/own-keys": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+            "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "get-intrinsic": "^1.2.6",
+                "object-keys": "^1.1.1",
+                "safe-push-apply": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/p-limit": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -6986,6 +9514,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/package-json-from-dist": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0"
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
@@ -7079,6 +9614,33 @@
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
         },
+        "node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/path-scurry/node_modules/lru-cache": {
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/path-to-regexp": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
@@ -7119,6 +9681,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/possible-typed-array-names": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+            "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/postcss": {
@@ -7187,6 +9759,19 @@
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"
+            }
+        },
+        "node_modules/pretty-bytes": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-6.1.1.tgz",
+            "integrity": "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/pretty-format": {
@@ -7309,6 +9894,16 @@
                 }
             ],
             "license": "MIT"
+        },
+        "node_modules/randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "^5.1.0"
+            }
         },
         "node_modules/react": {
             "version": "19.2.5",
@@ -7469,6 +10064,108 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/reflect.getprototypeof": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+            "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.9",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "get-intrinsic": "^1.2.7",
+                "get-proto": "^1.0.1",
+                "which-builtin-type": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/regenerate": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+            "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/regenerate-unicode-properties": {
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.2.tgz",
+            "integrity": "sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regenerate": "^1.4.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/regexp.prototype.flags": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+            "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "define-properties": "^1.2.1",
+                "es-errors": "^1.3.0",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "set-function-name": "^2.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/regexpu-core": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.4.0.tgz",
+            "integrity": "sha512-0ghuzq67LI9bLXpOX/ISfve/Mq33a4aFRzoQYhnnok1JOFpmE/A2TBGkNVenOGEeSBCjIiWcc6MVOG5HEQv0sA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "regenerate": "^1.4.2",
+                "regenerate-unicode-properties": "^10.2.2",
+                "regjsgen": "^0.8.0",
+                "regjsparser": "^0.13.0",
+                "unicode-match-property-ecmascript": "^2.0.0",
+                "unicode-match-property-value-ecmascript": "^2.2.1"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/regjsgen": {
+            "version": "0.8.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+            "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/regjsparser": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+            "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "jsesc": "~3.1.0"
+            },
+            "bin": {
+                "regjsparser": "bin/parser"
             }
         },
         "node_modules/remeda": {
@@ -7830,6 +10527,82 @@
                 "queue-microtask": "^1.2.2"
             }
         },
+        "node_modules/safe-array-concat": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+            "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.9",
+                "call-bound": "^1.0.4",
+                "get-intrinsic": "^1.3.0",
+                "has-symbols": "^1.1.0",
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">=0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/safe-push-apply": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+            "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "isarray": "^2.0.5"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/safe-regex-test": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "is-regex": "^1.2.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -7859,12 +10632,71 @@
                 "semver": "bin/semver.js"
             }
         },
+        "node_modules/serialize-javascript": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "randombytes": "^2.1.0"
+            }
+        },
         "node_modules/set-cookie-parser": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-3.1.0.tgz",
             "integrity": "sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/set-function-length": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.4",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/set-function-name": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+            "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "define-data-property": "^1.1.4",
+                "es-errors": "^1.3.0",
+                "functions-have-names": "^1.2.3",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/set-proto": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+            "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "dunder-proto": "^1.0.1",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -7887,6 +10719,82 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/side-channel": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.3",
+                "side-channel-list": "^1.0.0",
+                "side-channel-map": "^1.0.1",
+                "side-channel-weakmap": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-list": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+            "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "object-inspect": "^1.13.4"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-map": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/side-channel-weakmap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "es-errors": "^1.3.0",
+                "get-intrinsic": "^1.2.5",
+                "object-inspect": "^1.13.3",
+                "side-channel-map": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
             }
         },
         "node_modules/siginfo": {
@@ -7922,6 +10830,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/smob": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
+            "integrity": "sha512-KAkBqZl3c2GvNgNhcoyJae1aKldDW0LO279wF9bk1PnluRTETKBq0WyzRXxEhoQLk56yHaOY4JCBEKDuJIET5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -7940,6 +10858,35 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/source-map-support": {
+            "version": "0.5.21",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            }
+        },
+        "node_modules/source-map-support/node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/sourcemap-codec": {
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+            "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+            "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stackback": {
             "version": "0.0.2",
@@ -7964,6 +10911,20 @@
             "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/stop-iteration-iterator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+            "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "es-errors": "^1.3.0",
+                "internal-slot": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
         },
         "node_modules/strict-event-emitter": {
             "version": "0.5.1",
@@ -7997,6 +10958,108 @@
                 "node": ">=8"
             }
         },
+        "node_modules/string.prototype.matchall": {
+            "version": "4.0.12",
+            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+            "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.3",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.6",
+                "es-errors": "^1.3.0",
+                "es-object-atoms": "^1.0.0",
+                "get-intrinsic": "^1.2.6",
+                "gopd": "^1.2.0",
+                "has-symbols": "^1.1.0",
+                "internal-slot": "^1.1.0",
+                "regexp.prototype.flags": "^1.5.3",
+                "set-function-name": "^2.0.2",
+                "side-channel": "^1.1.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trim": {
+            "version": "1.2.10",
+            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+            "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
+                "define-data-property": "^1.1.4",
+                "define-properties": "^1.2.1",
+                "es-abstract": "^1.23.5",
+                "es-object-atoms": "^1.0.0",
+                "has-property-descriptors": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimend": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+            "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.2",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/string.prototype.trimstart": {
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+            "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "define-properties": "^1.2.1",
+                "es-object-atoms": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/stringify-object": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.3.0.tgz",
+            "integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "get-own-enumerable-property-symbols": "^3.0.0",
+                "is-obj": "^1.0.1",
+                "is-regexp": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -8008,6 +11071,16 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/strip-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-comments/-/strip-comments-2.0.1.tgz",
+            "integrity": "sha512-ZprKx+bBLXv067WTCALv8SSz5l2+XhpYCsVtSqlMnkAXMWDq+/ekVbl1ghqP9rUHTzv6sm/DwCOiYutU/yp1fw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/strip-final-newline": {
@@ -8099,6 +11172,87 @@
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
             }
+        },
+        "node_modules/temp-dir": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
+            "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/tempy": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
+            "integrity": "sha512-G13vtMYPT/J8A4X2SjdtBTphZlrp1gKv6hZiOjw14RCWg6GbHuQBGtjlx75xLbYV/wEc0D7G5K4rxKP/cXk8Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-stream": "^2.0.0",
+                "temp-dir": "^2.0.0",
+                "type-fest": "^0.16.0",
+                "unique-string": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tempy/node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/tempy/node_modules/type-fest": {
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.16.0.tgz",
+            "integrity": "sha512-eaBzG6MxNzEn9kiwvtre90cXaNLkmadMWa1zQMs3XORCXNbsH/OewwbxC5ia9dCxIxnTAsSxXJaa/p5y8DlvJg==",
+            "dev": true,
+            "license": "(MIT OR CC0-1.0)",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/terser": {
+            "version": "5.46.2",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.2.tgz",
+            "integrity": "sha512-uxfo9fPcSgLDYob/w1FuL0c99MWiJDnv+5qXSQc5+Ki5NjVNsYi66INnMFBjf6uFz6OnX12piJQPF4IpjJTNTw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.15.0",
+                "commander": "^2.20.0",
+                "source-map-support": "~0.5.20"
+            },
+            "bin": {
+                "terser": "bin/terser"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/terser/node_modules/commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/text-table": {
             "version": "0.2.0",
@@ -8304,6 +11458,84 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typed-array-buffer": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "es-errors": "^1.3.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
+        "node_modules/typed-array-byte-length": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+            "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.8",
+                "for-each": "^0.3.3",
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.14"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-byte-offset": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+            "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "for-each": "^0.3.3",
+                "gopd": "^1.2.0",
+                "has-proto": "^1.2.0",
+                "is-typed-array": "^1.1.15",
+                "reflect.getprototypeof": "^1.0.9"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/typed-array-length": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+            "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bind": "^1.0.7",
+                "for-each": "^0.3.3",
+                "gopd": "^1.0.1",
+                "is-typed-array": "^1.1.13",
+                "possible-typed-array-names": "^1.0.0",
+                "reflect.getprototypeof": "^1.0.6"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/typedoc": {
             "version": "0.28.19",
             "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
@@ -8447,6 +11679,25 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/unbox-primitive": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+            "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.3",
+                "has-bigints": "^1.0.2",
+                "has-symbols": "^1.1.0",
+                "which-boxed-primitive": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/undici": {
             "version": "7.25.0",
             "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
@@ -8464,6 +11715,50 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/unicode-canonical-property-names-ecmascript": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+            "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/unicode-match-property-ecmascript": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+            "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "unicode-canonical-property-names-ecmascript": "^2.0.0",
+                "unicode-property-aliases-ecmascript": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/unicode-match-property-value-ecmascript": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.1.tgz",
+            "integrity": "sha512-JQ84qTuMg4nVkx8ga4A16a1epI9H6uTXAknqxkGF/aFfRLw1xC/Bp24HNLaZhHSkWd3+84t8iXnp1J0kYcZHhg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/unicode-property-aliases-ecmascript": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.2.0.tgz",
+            "integrity": "sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/unicorn-magic": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
@@ -8475,6 +11770,19 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/unique-string": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+            "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "crypto-random-string": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/universal-cookie": {
@@ -8514,6 +11822,17 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/kettanaito"
+            }
+        },
+        "node_modules/upath": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4",
+                "yarn": "*"
             }
         },
         "node_modules/update-browserslist-db": {
@@ -8635,6 +11954,37 @@
                     "optional": true
                 },
                 "yaml": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vite-plugin-pwa": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/vite-plugin-pwa/-/vite-plugin-pwa-1.2.0.tgz",
+            "integrity": "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "debug": "^4.3.6",
+                "pretty-bytes": "^6.1.1",
+                "tinyglobby": "^0.2.10",
+                "workbox-build": "^7.4.0",
+                "workbox-window": "^7.4.0"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            },
+            "peerDependencies": {
+                "@vite-pwa/assets-generator": "^1.0.0",
+                "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+                "workbox-build": "^7.4.0",
+                "workbox-window": "^7.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@vite-pwa/assets-generator": {
                     "optional": true
                 }
             }
@@ -9321,6 +12671,95 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/which-boxed-primitive": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+            "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-bigint": "^1.1.0",
+                "is-boolean-object": "^1.2.1",
+                "is-number-object": "^1.1.1",
+                "is-string": "^1.1.1",
+                "is-symbol": "^1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-builtin-type": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+            "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "call-bound": "^1.0.2",
+                "function.prototype.name": "^1.1.6",
+                "has-tostringtag": "^1.0.2",
+                "is-async-function": "^2.0.0",
+                "is-date-object": "^1.1.0",
+                "is-finalizationregistry": "^1.1.0",
+                "is-generator-function": "^1.0.10",
+                "is-regex": "^1.2.1",
+                "is-weakref": "^1.0.2",
+                "isarray": "^2.0.5",
+                "which-boxed-primitive": "^1.1.0",
+                "which-collection": "^1.0.2",
+                "which-typed-array": "^1.1.16"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-collection": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+            "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "is-map": "^2.0.3",
+                "is-set": "^2.0.3",
+                "is-weakmap": "^2.0.2",
+                "is-weakset": "^2.0.3"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/which-typed-array": {
+            "version": "1.1.20",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
+            "integrity": "sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "available-typed-arrays": "^1.0.7",
+                "call-bind": "^1.0.8",
+                "call-bound": "^1.0.4",
+                "for-each": "^0.3.5",
+                "get-proto": "^1.0.1",
+                "gopd": "^1.2.0",
+                "has-tostringtag": "^1.0.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        },
         "node_modules/why-is-node-running": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -9346,6 +12785,496 @@
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/workbox-background-sync": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-background-sync/-/workbox-background-sync-7.4.0.tgz",
+            "integrity": "sha512-8CB9OxKAgKZKyNMwfGZ1XESx89GryWTfI+V5yEj8sHjFH8MFelUwYXEyldEK6M6oKMmn807GoJFUEA1sC4XS9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "idb": "^7.0.1",
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-broadcast-update": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-broadcast-update/-/workbox-broadcast-update-7.4.0.tgz",
+            "integrity": "sha512-+eZQwoktlvo62cI0b+QBr40v5XjighxPq3Fzo9AWMiAosmpG5gxRHgTbGGhaJv/q/MFVxwFNGh/UwHZ/8K88lA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-build": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-build/-/workbox-build-7.4.0.tgz",
+            "integrity": "sha512-Ntk1pWb0caOFIvwz/hfgrov/OJ45wPEhI5PbTywQcYjyZiVhT3UrwwUPl6TRYbTm4moaFYithYnl1lvZ8UjxcA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@apideck/better-ajv-errors": "^0.3.1",
+                "@babel/core": "^7.24.4",
+                "@babel/preset-env": "^7.11.0",
+                "@babel/runtime": "^7.11.2",
+                "@rollup/plugin-babel": "^5.2.0",
+                "@rollup/plugin-node-resolve": "^15.2.3",
+                "@rollup/plugin-replace": "^2.4.1",
+                "@rollup/plugin-terser": "^0.4.3",
+                "@surma/rollup-plugin-off-main-thread": "^2.2.3",
+                "ajv": "^8.6.0",
+                "common-tags": "^1.8.0",
+                "fast-json-stable-stringify": "^2.1.0",
+                "fs-extra": "^9.0.1",
+                "glob": "^11.0.1",
+                "lodash": "^4.17.20",
+                "pretty-bytes": "^5.3.0",
+                "rollup": "^2.79.2",
+                "source-map": "^0.8.0-beta.0",
+                "stringify-object": "^3.3.0",
+                "strip-comments": "^2.0.1",
+                "tempy": "^0.6.0",
+                "upath": "^1.2.0",
+                "workbox-background-sync": "7.4.0",
+                "workbox-broadcast-update": "7.4.0",
+                "workbox-cacheable-response": "7.4.0",
+                "workbox-core": "7.4.0",
+                "workbox-expiration": "7.4.0",
+                "workbox-google-analytics": "7.4.0",
+                "workbox-navigation-preload": "7.4.0",
+                "workbox-precaching": "7.4.0",
+                "workbox-range-requests": "7.4.0",
+                "workbox-recipes": "7.4.0",
+                "workbox-routing": "7.4.0",
+                "workbox-strategies": "7.4.0",
+                "workbox-streams": "7.4.0",
+                "workbox-sw": "7.4.0",
+                "workbox-window": "7.4.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/workbox-build/node_modules/@apideck/better-ajv-errors": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/@apideck/better-ajv-errors/-/better-ajv-errors-0.3.7.tgz",
+            "integrity": "sha512-TajUJwGWbDwkCx/CZi7tRE8PVB7simCvKJfHUsSdvps+aTM/PDPP4gkLmKnc+x3CE//y9i/nj74GqdL/hwk7Iw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "jsonpointer": "^5.0.1",
+                "leven": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "peerDependencies": {
+                "ajv": ">=8"
+            }
+        },
+        "node_modules/workbox-build/node_modules/@rollup/plugin-babel": {
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.3.1.tgz",
+            "integrity": "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-imports": "^7.10.4",
+                "@rollup/pluginutils": "^3.1.0"
+            },
+            "engines": {
+                "node": ">= 10.0.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0",
+                "@types/babel__core": "^7.1.9",
+                "rollup": "^1.20.0||^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/babel__core": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/workbox-build/node_modules/@rollup/plugin-replace": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-2.4.2.tgz",
+            "integrity": "sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^3.1.0",
+                "magic-string": "^0.25.7"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0 || ^2.0.0"
+            }
+        },
+        "node_modules/workbox-build/node_modules/@rollup/pluginutils": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+            "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "0.0.39",
+                "estree-walker": "^1.0.1",
+                "picomatch": "^2.2.2"
+            },
+            "engines": {
+                "node": ">= 8.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0"
+            }
+        },
+        "node_modules/workbox-build/node_modules/@types/estree": {
+            "version": "0.0.39",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+            "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-build/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/workbox-build/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/workbox-build/node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/workbox-build/node_modules/estree-walker": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+            "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-build/node_modules/fs-extra": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+            "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "at-least-node": "^1.0.0",
+                "graceful-fs": "^4.2.0",
+                "jsonfile": "^6.0.1",
+                "universalify": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/workbox-build/node_modules/glob": {
+            "version": "11.1.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+            "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "foreground-child": "^3.3.1",
+                "jackspeak": "^4.1.1",
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^2.0.0"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/workbox-build/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-build/node_modules/leven": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
+            "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/workbox-build/node_modules/magic-string": {
+            "version": "0.25.9",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+            "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sourcemap-codec": "^1.4.8"
+            }
+        },
+        "node_modules/workbox-build/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/workbox-build/node_modules/pretty-bytes": {
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+            "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/workbox-build/node_modules/rollup": {
+            "version": "2.80.0",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
+            "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "rollup": "dist/bin/rollup"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/workbox-build/node_modules/source-map": {
+            "version": "0.8.0-beta.0",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
+            "integrity": "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==",
+            "deprecated": "The work that was done in this beta branch won't be included in future versions",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "whatwg-url": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/workbox-build/node_modules/tr46": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+            "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/workbox-build/node_modules/webidl-conversions": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+            "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+            "dev": true,
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/workbox-build/node_modules/whatwg-url": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-7.1.0.tgz",
+            "integrity": "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.sortby": "^4.7.0",
+                "tr46": "^1.0.1",
+                "webidl-conversions": "^4.0.2"
+            }
+        },
+        "node_modules/workbox-cacheable-response": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-7.4.0.tgz",
+            "integrity": "sha512-0Fb8795zg/x23ISFkAc7lbWes6vbw34DGFIMw31cwuHPgDEC/5EYm6m/ZkylLX0EnEbbOyOCLjKgFS/Z5g0HeQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-core": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-core/-/workbox-core-7.4.0.tgz",
+            "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-expiration": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-expiration/-/workbox-expiration-7.4.0.tgz",
+            "integrity": "sha512-V50p4BxYhtA80eOvulu8xVfPBgZbkxJ1Jr8UUn0rvqjGhLDqKNtfrDfjJKnLz2U8fO2xGQJTx/SKXNTzHOjnHw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "idb": "^7.0.1",
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-google-analytics": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-google-analytics/-/workbox-google-analytics-7.4.0.tgz",
+            "integrity": "sha512-MVPXQslRF6YHkzGoFw1A4GIB8GrKym/A5+jYDUSL+AeJw4ytQGrozYdiZqUW1TPQHW8isBCBtyFJergUXyNoWQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-background-sync": "7.4.0",
+                "workbox-core": "7.4.0",
+                "workbox-routing": "7.4.0",
+                "workbox-strategies": "7.4.0"
+            }
+        },
+        "node_modules/workbox-navigation-preload": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-navigation-preload/-/workbox-navigation-preload-7.4.0.tgz",
+            "integrity": "sha512-etzftSgdQfjMcfPgbfaZCfM2QuR1P+4o8uCA2s4rf3chtKTq/Om7g/qvEOcZkG6v7JZOSOxVYQiOu6PbAZgU6w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-precaching": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-precaching/-/workbox-precaching-7.4.0.tgz",
+            "integrity": "sha512-VQs37T6jDqf1rTxUJZXRl3yjZMf5JX/vDPhmx2CPgDDKXATzEoqyRqhYnRoxl6Kr0rqaQlp32i9rtG5zTzIlNg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0",
+                "workbox-routing": "7.4.0",
+                "workbox-strategies": "7.4.0"
+            }
+        },
+        "node_modules/workbox-range-requests": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-range-requests/-/workbox-range-requests-7.4.0.tgz",
+            "integrity": "sha512-3Vq854ZNuP6Y0KZOQWLaLC9FfM7ZaE+iuQl4VhADXybwzr4z/sMmnLgTeUZLq5PaDlcJBxYXQ3U91V7dwAIfvw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-recipes": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-recipes/-/workbox-recipes-7.4.0.tgz",
+            "integrity": "sha512-kOkWvsAn4H8GvAkwfJTbwINdv4voFoiE9hbezgB1sb/0NLyTG4rE7l6LvS8lLk5QIRIto+DjXLuAuG3Vmt3cxQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-cacheable-response": "7.4.0",
+                "workbox-core": "7.4.0",
+                "workbox-expiration": "7.4.0",
+                "workbox-precaching": "7.4.0",
+                "workbox-routing": "7.4.0",
+                "workbox-strategies": "7.4.0"
+            }
+        },
+        "node_modules/workbox-routing": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-routing/-/workbox-routing-7.4.0.tgz",
+            "integrity": "sha512-C/ooj5uBWYAhAqwmU8HYQJdOjjDKBp9MzTQ+otpMmd+q0eF59K+NuXUek34wbL0RFrIXe/KKT+tUWcZcBqxbHQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-strategies": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-strategies/-/workbox-strategies-7.4.0.tgz",
+            "integrity": "sha512-T4hVqIi5A4mHi92+5EppMX3cLaVywDp8nsyUgJhOZxcfSV/eQofcOA6/EMo5rnTNmNTpw0rUgjAI6LaVullPpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0"
+            }
+        },
+        "node_modules/workbox-streams": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-streams/-/workbox-streams-7.4.0.tgz",
+            "integrity": "sha512-QHPBQrey7hQbnTs5GrEVoWz7RhHJXnPT+12qqWM378orDMo5VMJLCkCM1cnCk+8Eq92lccx/VgRZ7WAzZWbSLg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "workbox-core": "7.4.0",
+                "workbox-routing": "7.4.0"
+            }
+        },
+        "node_modules/workbox-sw": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-sw/-/workbox-sw-7.4.0.tgz",
+            "integrity": "sha512-ltU+Kr3qWR6BtbdlMnCjobZKzeV1hN+S6UvDywBrwM19TTyqA03X66dzw1tEIdJvQ4lYKkBFox6IAEhoSEZ8Xw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/workbox-window": {
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/workbox-window/-/workbox-window-7.4.0.tgz",
+            "integrity": "sha512-/bIYdBLAVsNR3v7gYGaV4pQW3M3kEPx5E8vDxGvxo6khTrGtSSCS7QiFKv9ogzBgZiy0OXLP9zO28U/1nF1mfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/trusted-types": "^2.0.2",
+                "workbox-core": "7.4.0"
             }
         },
         "node_modules/wrap-ansi": {

--- a/edukate-frontend/package.json
+++ b/edukate-frontend/package.json
@@ -61,6 +61,7 @@
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.22.0",
         "vite": "^6.1.0",
+        "vite-plugin-pwa": "^1.2.0",
         "vitest": "^4.1.3"
     }
 }

--- a/edukate-frontend/public/site.webmanifest
+++ b/edukate-frontend/public/site.webmanifest
@@ -1,6 +1,14 @@
 {
     "name": "Edukate",
     "short_name": "Edukate",
+    "description": "Physics problem-solving platform",
+    "start_url": "/",
+    "scope": "/",
+    "id": "/",
+    "display": "standalone",
+    "orientation": "any",
+    "theme_color": "#851691",
+    "background_color": "#f9ebd9",
     "icons": [
         {
             "src": "/android-chrome-192x192.png",
@@ -11,9 +19,12 @@
             "src": "/android-chrome-512x512.png",
             "sizes": "512x512",
             "type": "image/png"
+        },
+        {
+            "src": "/android-chrome-512x512.png",
+            "sizes": "512x512",
+            "type": "image/png",
+            "purpose": "maskable"
         }
-    ],
-    "theme_color": "#851691",
-    "background_color": "#f9ebd9",
-    "display": "standalone"
+    ]
 }

--- a/edukate-frontend/src/app/providers.tsx
+++ b/edukate-frontend/src/app/providers.tsx
@@ -6,6 +6,7 @@ import { CookiesProvider } from "react-cookie";
 import { queryClient } from "@/lib/query-client";
 import { CssBaseline } from "@mui/material";
 import { DeviceProvider } from "@/shared/context/DeviceContext";
+import { PwaProvider } from "@/shared/context/PwaContext";
 
 interface ProvidersProps {
     children: ReactNode;
@@ -13,15 +14,17 @@ interface ProvidersProps {
 
 export function Providers({ children }: ProvidersProps) {
     return (
-        <QueryClientProvider client={queryClient}>
-            <CssBaseline />
-            <ThemeProvider>
-                <AuthProvider>
-                    <CookiesProvider defaultSetOptions={{ path: "/" }}>
-                        <DeviceProvider>{children}</DeviceProvider>
-                    </CookiesProvider>
-                </AuthProvider>
-            </ThemeProvider>
-        </QueryClientProvider>
+        <PwaProvider>
+            <QueryClientProvider client={queryClient}>
+                <CssBaseline />
+                <ThemeProvider>
+                    <AuthProvider>
+                        <CookiesProvider defaultSetOptions={{ path: "/" }}>
+                            <DeviceProvider>{children}</DeviceProvider>
+                        </CookiesProvider>
+                    </AuthProvider>
+                </ThemeProvider>
+            </QueryClientProvider>
+        </PwaProvider>
     );
 }

--- a/edukate-frontend/src/features/checks/components/CheckResultDetailDialog.tsx
+++ b/edukate-frontend/src/features/checks/components/CheckResultDetailDialog.tsx
@@ -17,6 +17,7 @@ import DoneIcon from "@mui/icons-material/DoneOutlined";
 import ErrorIcon from "@mui/icons-material/Error";
 import InternalIcon from "@mui/icons-material/Storage";
 import { useCheckResultDetailQuery } from "@/features/checks/api";
+import { useDeviceContext } from "@/shared/context/DeviceContext";
 import { CheckResultDto, CheckResultDtoErrorType } from "@/features/checks/types";
 import { formatDate } from "@/shared/utils/date";
 
@@ -27,9 +28,10 @@ type CheckResultDetailDialogProps = {
 
 export const CheckResultDetailDialog: FC<CheckResultDetailDialogProps> = ({ checkResultId, onClose }) => {
     const { data, isLoading } = useCheckResultDetailQuery(checkResultId);
+    const { isMobile } = useDeviceContext();
 
     return (
-        <Dialog open={checkResultId !== null} onClose={onClose} maxWidth="sm" fullWidth>
+        <Dialog open={checkResultId !== null} onClose={onClose} maxWidth="sm" fullWidth fullScreen={isMobile}>
             <DialogTitle component="div">
                 <Stack direction="row" alignItems="center" justifyContent="space-between">
                     <Stack direction="row" alignItems="center" spacing={1.5}>

--- a/edukate-frontend/src/features/files/components/FileInput.tsx
+++ b/edukate-frontend/src/features/files/components/FileInput.tsx
@@ -5,7 +5,7 @@ import { defaultTooltipSlotProps, formatFileSize } from "@/shared/utils/utils";
 import { FileDragAndDrop } from "./FileDragAndDrop";
 import { FileStatusIcon } from "./FileStatusIcon";
 import { useFileUpload } from "@/features/files/hooks/useFileUpload";
-import { FilePreviewDialog } from "./FilePreviewDialog";
+import { FileLightbox } from "./FileLightbox";
 import { toast } from "react-toastify";
 
 type FileInputProps = {
@@ -119,7 +119,7 @@ export const FileInput: FC<FileInputProps> = ({
                 </ListItem>
             ))}
 
-            <FilePreviewDialog open={previewDialogOpen} fileKey={selectedFileKey} onClose={handleClosePreview} />
+            <FileLightbox open={previewDialogOpen} fileKey={selectedFileKey} onClose={handleClosePreview} />
         </List>
     );
 };

--- a/edukate-frontend/src/features/files/components/FileLightbox.tsx
+++ b/edukate-frontend/src/features/files/components/FileLightbox.tsx
@@ -1,0 +1,29 @@
+import { FC, useEffect, useState } from "react";
+import { useGetTempFile } from "@/features/files/api";
+import { ImageLightbox } from "@/shared/components/images/ImageLightbox";
+
+interface FileLightboxProps {
+    open: boolean;
+    fileKey: string | undefined;
+    onClose: () => void;
+}
+
+export const FileLightbox: FC<FileLightboxProps> = ({ open, fileKey, onClose }) => {
+    const { data: fileBlob } = useGetTempFile(fileKey);
+    const [objectUrl, setObjectUrl] = useState<string>();
+
+    useEffect(() => {
+        if (fileBlob) {
+            const url = URL.createObjectURL(fileBlob);
+            setObjectUrl(url);
+            return () => {
+                URL.revokeObjectURL(url);
+                setObjectUrl(undefined);
+            };
+        }
+    }, [fileBlob]);
+
+    if (!objectUrl) return null;
+
+    return <ImageLightbox images={[objectUrl]} index={0} open={open} onClose={onClose} />;
+};

--- a/edukate-frontend/src/features/files/components/FileUpload.tsx
+++ b/edukate-frontend/src/features/files/components/FileUpload.tsx
@@ -18,7 +18,7 @@ export function FileUpload({ accept = "*", maxSize = 50 * 1024 * 1024, maxFiles 
         setUploadedFileNames((prevState) => prevState.filter((key) => key !== fileKey));
     };
     return (
-        <Paper elevation={2} sx={{ p: 1, borderRadius: 2, width: "80%" }}>
+        <Paper elevation={2} sx={{ p: 1, borderRadius: 2, width: { xs: "100%", sm: "80%" } }}>
             <Box gap={2}>
                 <FileInput
                     onTempFileUploaded={addFileKey}

--- a/edukate-frontend/src/features/files/components/MobileFileInput.tsx
+++ b/edukate-frontend/src/features/files/components/MobileFileInput.tsx
@@ -6,7 +6,7 @@ import { FileStatusIcon } from "./FileStatusIcon";
 import { useFileUpload } from "@/features/files/hooks/useFileUpload";
 import { useFileStatsDisplayValues } from "@/features/files/hooks/useFileStatsDisplayValues";
 import UploadIcon from "@mui/icons-material/Upload";
-import { FilePreviewDialog } from "./FilePreviewDialog";
+import { FileLightbox } from "./FileLightbox";
 import { toast } from "react-toastify";
 
 type MobileFileInputProps = {
@@ -65,7 +65,7 @@ export const MobileFileInput: FC<MobileFileInputProps> = ({
                 inputProps={{ multiple: true, accept: accept }}
             />
 
-            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", pb: 1 }}>
+            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", p: 1 }}>
                 <Box sx={{ display: "flex", flexDirection: "column" }}>
                     <Typography variant="subtitle1" textAlign={"start"}>
                         {primaryText}
@@ -136,7 +136,7 @@ export const MobileFileInput: FC<MobileFileInputProps> = ({
                 </ListItem>
             ))}
 
-            <FilePreviewDialog open={previewDialogOpen} fileKey={selectedFileKey} onClose={handleClosePreview} />
+            <FileLightbox open={previewDialogOpen} fileKey={selectedFileKey} onClose={handleClosePreview} />
         </List>
     );
 };

--- a/edukate-frontend/src/features/files/components/MobileFileUpload.tsx
+++ b/edukate-frontend/src/features/files/components/MobileFileUpload.tsx
@@ -1,4 +1,4 @@
-import { Box, Fab, Paper, SwipeableDrawer, Button } from "@mui/material";
+import { Box, Fab, SwipeableDrawer, Button } from "@mui/material";
 import { useState, useRef } from "react";
 import { MobileFileInput } from "./MobileFileInput";
 import AddIcon from "@mui/icons-material/Add";
@@ -60,23 +60,19 @@ export function MobileFileUpload({
                 ModalProps={{ keepMounted: true }}
                 sx={{ "& .MuiDrawer-paper": { height: "auto", overflow: "visible" } }}
             >
-                <Box sx={{ px: 2, height: "100%", overflow: "auto" }}>
-                    <Paper elevation={0} sx={{ p: 1, borderRadius: 2, width: "100%" }}>
-                        <Box gap={2} pt={1}>
-                            <MobileFileInput
-                                onTempFileUploaded={addFileKey}
-                                onTempFileDeleted={deleteFileKey}
-                                accept={accept}
-                                maxFiles={maxFiles}
-                                maxSize={maxSize}
-                            />
-                            {onSubmit && uploadedFileNames.length > 0 && (
-                                <Button color="secondary" onClick={handleSubmit} sx={{ my: 1, width: "100%" }}>
-                                    Submit
-                                </Button>
-                            )}
-                        </Box>
-                    </Paper>
+                <Box sx={{ px: 1, pt: 1, height: "100%", overflowX: "hidden", overflowY: "auto" }}>
+                    <MobileFileInput
+                        onTempFileUploaded={addFileKey}
+                        onTempFileDeleted={deleteFileKey}
+                        accept={accept}
+                        maxFiles={maxFiles}
+                        maxSize={maxSize}
+                    />
+                    {onSubmit && uploadedFileNames.length > 0 && (
+                        <Button color="secondary" onClick={handleSubmit} sx={{ my: 1, width: "100%" }}>
+                            Submit
+                        </Button>
+                    )}
                 </Box>
             </SwipeableDrawer>
         </Box>

--- a/edukate-frontend/src/features/notifications/components/InvitationDialog.tsx
+++ b/edukate-frontend/src/features/notifications/components/InvitationDialog.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from "@mui/material";
 import { GroupAdd } from "@mui/icons-material";
 import { FC } from "react";
+import { useDeviceContext } from "@/shared/context/DeviceContext";
 
 type ProblemSetInviteInfo = {
     problemSetName: string;
@@ -13,9 +14,12 @@ interface InvitationDialogProps {
 }
 
 export const InvitationDialog: FC<InvitationDialogProps> = ({ problemSetInfo, onClose }) => {
+    const { isMobile } = useDeviceContext();
     return (
         <Dialog
             open={problemSetInfo != undefined}
+            fullWidth
+            fullScreen={isMobile}
             onClose={() => {
                 onClose(undefined);
             }}

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetComponent.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetComponent.tsx
@@ -36,7 +36,7 @@ export function ProblemSetComponent({ problemSetCode }: ProblemSetComponentProps
                 </Typography>
             )}
             <Grid container spacing={1} paddingTop={"1rem"}>
-                <Grid sx={{ sm: "none", md: "block" }} key={"left-grid"} size={"grow"}>
+                <Grid sx={{ display: { xs: "none", md: "block" } }} key={"left-grid"} size={"grow"}>
                     <Card>
                         <ProblemSetProblemSelector
                             problems={problemSet ? problemSet.problems : []}

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetDescriptionTab.test.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetDescriptionTab.test.tsx
@@ -4,7 +4,15 @@ import { ProblemSet } from "@/features/problem-sets/types";
 import { ProblemMetadata } from "@/features/problems/types";
 
 function makeProblem(status: ProblemMetadata["status"], code: string = "1.1"): ProblemMetadata {
-    return { key: `savchenko/${code}`, code, bookSlug: "savchenko", isHard: false, tags: [], status };
+    return {
+        key: `savchenko/${code}`,
+        code,
+        bookSlug: "savchenko",
+        isHard: false,
+        tags: [],
+        status,
+        createdAt: "2026-01-01T00:00:00Z",
+    };
 }
 
 const baseProblemSet: ProblemSet = {

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemSelector.test.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemSelector.test.tsx
@@ -4,8 +4,24 @@ import { ProblemSetProblemSelector, ProblemSetSelection } from "./ProblemSetProb
 import { ProblemMetadata } from "@/features/problems/types";
 
 const problems: ProblemMetadata[] = [
-    { key: "savchenko/1.1", code: "1.1", bookSlug: "savchenko", isHard: false, tags: [], status: "SOLVED" },
-    { key: "savchenko/1.2", code: "1.2", bookSlug: "savchenko", isHard: true, tags: [], status: "NOT_SOLVED" },
+    {
+        key: "savchenko/1.1",
+        code: "1.1",
+        bookSlug: "savchenko",
+        isHard: false,
+        tags: [],
+        status: "SOLVED",
+        createdAt: "2026-01-01T00:00:00Z",
+    },
+    {
+        key: "savchenko/1.2",
+        code: "1.2",
+        bookSlug: "savchenko",
+        isHard: true,
+        tags: [],
+        status: "NOT_SOLVED",
+        createdAt: "2026-01-01T00:00:00Z",
+    },
 ];
 
 const defaultSelection: ProblemSetSelection = { type: "description" };

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemSelector.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemSelector.tsx
@@ -69,7 +69,7 @@ export function ProblemSetProblemSelector({
                             onSelectionChange({ type: "description" });
                         }}
                     >
-                        <ListItemIcon>
+                        <ListItemIcon sx={{ minWidth: { md: 36, lg: 56 } }}>
                             <InfoOutlinedIcon />
                         </ListItemIcon>
                         <ListItemText primary="Description" />
@@ -81,7 +81,7 @@ export function ProblemSetProblemSelector({
                                 onSelectionChange({ type: "settings" });
                             }}
                         >
-                            <ListItemIcon>
+                            <ListItemIcon sx={{ minWidth: { md: 36, lg: 56 } }}>
                                 <SettingsOutlinedIcon />
                             </ListItemIcon>
                             <ListItemText primary="Settings" />
@@ -98,7 +98,7 @@ export function ProblemSetProblemSelector({
                                 onSelectionChange({ type: "problem", problem });
                             }}
                         >
-                            <ListItemIcon>
+                            <ListItemIcon sx={{ minWidth: { md: 36, lg: 56 } }}>
                                 <ProblemStatusIcon status={problem.status} />
                             </ListItemIcon>
                             <ListItemText primary={problem.code} />

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetSettingsTab.test.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetSettingsTab.test.tsx
@@ -6,7 +6,15 @@ import { ProblemSet } from "@/features/problem-sets/types";
 import { ProblemMetadata } from "@/features/problems/types";
 
 function makeProblem(status: ProblemMetadata["status"], code: string = "1.1"): ProblemMetadata {
-    return { key: `savchenko/${code}`, code, bookSlug: "savchenko", isHard: false, tags: [], status };
+    return {
+        key: `savchenko/${code}`,
+        code,
+        bookSlug: "savchenko",
+        isHard: false,
+        tags: [],
+        status,
+        createdAt: "2026-01-01T00:00:00Z",
+    };
 }
 
 const baseProblemSet: ProblemSet = {

--- a/edukate-frontend/src/features/problems/components/AnswerAccordion.tsx
+++ b/edukate-frontend/src/features/problems/components/AnswerAccordion.tsx
@@ -15,7 +15,7 @@ export function AnswerAccordionComponent({ problem }: AnswerComponentProps) {
     if (!result) return null;
 
     return (
-        <Box width={"80%"}>
+        <Box sx={{ width: { xs: "100%", sm: "80%" } }}>
             <Accordion disabled={!isAuthorized}>
                 <AccordionSummary expandIcon={<ExpandMoreIcon />} aria-controls="answer-content" id="answer-header">
                     <Typography component="span">Show the answer</Typography>

--- a/edukate-frontend/src/features/problems/components/ProblemListComponent.tsx
+++ b/edukate-frontend/src/features/problems/components/ProblemListComponent.tsx
@@ -6,10 +6,12 @@ import { ProblemTableToolbar } from "./table/ProblemTableToolbar";
 import { ProblemTableRows } from "./table/ProblemTableRows";
 import { ProblemTablePagination } from "./table/ProblemTablePagination";
 import { useProblemTableParams, DEFAULT_PAGE_SIZE } from "@/features/problems/hooks/useProblemTableParams";
-import { RandomProblemButton } from "./table/RandomProblemButton";
+import { RandomProblemButton, RandomProblemFab } from "./table/RandomProblemButton";
+import { useDeviceContext } from "@/shared/context/DeviceContext";
 
 export default function ProblemListComponent() {
     const navigate = useNavigate();
+    const { isMobile } = useDeviceContext();
     const navigateToProblem = (problemKey: string) => {
         void navigate(`/problems/${problemKey}`);
     };
@@ -34,7 +36,7 @@ export default function ProblemListComponent() {
     return (
         <Box>
             <ProblemTable
-                headerCells={["", "Book", "Name", "Tags"]}
+                headerCells={["", "Book", "Name", "Tags", "Created"]}
                 toolbar={
                     <ProblemTableToolbar
                         status={status}
@@ -49,7 +51,7 @@ export default function ProblemListComponent() {
                         onHasResultChange={handlers.onChangeHasResult}
                         bookSlug={bookSlug}
                         onBookSlugChange={handlers.onChangeBookSlug}
-                        rightSlot={<RandomProblemButton />}
+                        rightSlot={!isMobile && <RandomProblemButton />}
                     />
                 }
                 footer={
@@ -71,6 +73,7 @@ export default function ProblemListComponent() {
                     onBookSlugClick={handlers.onChangeBookSlug}
                 />
             </ProblemTable>
+            {isMobile && <RandomProblemFab />}
         </Box>
     );
 }

--- a/edukate-frontend/src/features/problems/components/ProblemStatusIcon.tsx
+++ b/edukate-frontend/src/features/problems/components/ProblemStatusIcon.tsx
@@ -1,8 +1,8 @@
 import { ProblemStatus } from "@/features/problems/types";
 import { Box, Tooltip } from "@mui/material";
-import DoneIcon from "@mui/icons-material/DoneOutlined";
-import CloseIcon from "@mui/icons-material/CloseOutlined";
-import PendingIcon from "@mui/icons-material/PendingOutlined";
+import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
+import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import { defaultTooltipSlotProps } from "@/shared/utils/utils";
 
 interface ProblemStatusIconProps {
@@ -14,17 +14,17 @@ export function ProblemStatusIcon({ status }: ProblemStatusIconProps) {
         <Box justifyContent={"left"} alignContent={"center"} display={"flex"}>
             {status == "SOLVED" && (
                 <Tooltip title={"Solved"} slotProps={defaultTooltipSlotProps}>
-                    <DoneIcon color="success" />
+                    <CheckCircleOutlineIcon color="success" />
                 </Tooltip>
             )}
             {status == "FAILED" && (
                 <Tooltip title={"Failed"} slotProps={defaultTooltipSlotProps}>
-                    <CloseIcon color="error" />
+                    <CancelOutlinedIcon color="error" />
                 </Tooltip>
             )}
             {status == "SOLVING" && (
                 <Tooltip title={"Pending review"} slotProps={defaultTooltipSlotProps}>
-                    <PendingIcon color="warning" />
+                    <HourglassEmptyIcon color="warning" />
                 </Tooltip>
             )}
         </Box>

--- a/edukate-frontend/src/features/problems/components/cards/SubmissionsCard.tsx
+++ b/edukate-frontend/src/features/problems/components/cards/SubmissionsCard.tsx
@@ -21,7 +21,7 @@ export default function SubmissionsCard({ problemKey }: SubmissionsCardProps) {
                     <Paper
                         elevation={0}
                         variant={"outlined"}
-                        sx={{ width: "80%", justifyContent: "center", margin: "auto" }}
+                        sx={{ width: { xs: "100%", sm: "80%" }, justifyContent: "center", margin: "auto" }}
                     >
                         <SubmissionList problemKey={problemKey} onSubmissionClick={setSelectedSubmission} />
                     </Paper>

--- a/edukate-frontend/src/features/problems/components/table/ProblemTable.tsx
+++ b/edukate-frontend/src/features/problems/components/table/ProblemTable.tsx
@@ -9,6 +9,11 @@ type ProblemTableProps = {
 };
 
 const headerTableCellSx = { minWidth: 44, maxWidth: 44, width: 44, p: 0.5 } as const;
+/** Per-column responsive visibility: Tags (3) hidden below md, Created (4) hidden on xs only */
+const columnVisibility: Record<number, object> = {
+    3: { display: { xs: "none", md: "table-cell" } },
+    4: { display: { xs: "none", sm: "table-cell" } },
+};
 
 export const ProblemTable: FC<ProblemTableProps> = ({ headerCells, toolbar, children, footer }) => {
     return (
@@ -21,7 +26,10 @@ export const ProblemTable: FC<ProblemTableProps> = ({ headerCells, toolbar, chil
                             <TableCell
                                 key={`header-${String(i)}`}
                                 align={i === 0 ? "center" : undefined}
-                                sx={i === 0 ? headerTableCellSx : undefined}
+                                sx={{
+                                    ...(i === 0 ? headerTableCellSx : {}),
+                                    ...columnVisibility[i],
+                                }}
                             >
                                 {h}
                             </TableCell>

--- a/edukate-frontend/src/features/problems/components/table/ProblemTablePagination.tsx
+++ b/edukate-frontend/src/features/problems/components/table/ProblemTablePagination.tsx
@@ -30,7 +30,7 @@ export const ProblemTablePagination: FC<Props> = ({
                 <TableCell colSpan={colSpan} sx={{ py: 1 }}>
                     <Box sx={{ display: "flex", alignItems: "center" }}>
                         <Box sx={{ flex: 1, display: "flex", alignItems: "center", gap: 1 }}>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" color="text.secondary" sx={{ display: { xs: "none", md: "block" } }}>
                                 Rows per page:
                             </Typography>
                             <Select
@@ -59,7 +59,11 @@ export const ProblemTablePagination: FC<Props> = ({
 
                         <Box sx={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
                             <Typography variant="body2" color="text.secondary">
-                                {from}–{to} of {count} problems
+                                {from}–{to} of {count}
+                                <Box component="span" sx={{ display: { xs: "none", md: "inline" } }}>
+                                    {" "}
+                                    problems
+                                </Box>
                             </Typography>
                         </Box>
                     </Box>

--- a/edukate-frontend/src/features/problems/components/table/ProblemTableRows.tsx
+++ b/edukate-frontend/src/features/problems/components/table/ProblemTableRows.tsx
@@ -1,8 +1,10 @@
 import { FC } from "react";
-import { TableRow, TableCell, Skeleton, Stack, Chip } from "@mui/material";
+import { TableRow, TableCell, Skeleton, Stack, SxProps, Theme } from "@mui/material";
 import { ProblemMetadata } from "@/features/problems/types";
 import { ProblemStatusIcon } from "@/features/problems/components/ProblemStatusIcon";
 import { TagChip } from "@/shared/components/TagChip";
+import { BookChip } from "@/shared/components/BookChip";
+import { formatRelative } from "@/shared/utils/date";
 
 type ProblemTableRowsProps = {
     items: ProblemMetadata[] | undefined;
@@ -10,6 +12,12 @@ type ProblemTableRowsProps = {
     error: unknown;
     onRowClick: (key: string) => void;
     onBookSlugClick: (slug: string) => void;
+};
+
+/** Per-column responsive visibility: Tags (3) hidden below md, Created (4) hidden on xs only */
+const columnVisibility: Record<number, SxProps<Theme>> = {
+    3: { display: { xs: "none", md: "table-cell" } },
+    4: { display: { xs: "none", sm: "table-cell" } },
 };
 
 export const ProblemTableRows: FC<ProblemTableRowsProps> = ({ items, loading, error, onRowClick, onBookSlugClick }) => {
@@ -27,7 +35,10 @@ export const ProblemTableRows: FC<ProblemTableRowsProps> = ({ items, loading, er
                         <TableCell>
                             <Skeleton variant="rounded" />
                         </TableCell>
-                        <TableCell>
+                        <TableCell sx={columnVisibility[3]}>
+                            <Skeleton variant="rounded" />
+                        </TableCell>
+                        <TableCell sx={columnVisibility[4]}>
                             <Skeleton variant="rounded" />
                         </TableCell>
                     </TableRow>
@@ -55,28 +66,20 @@ export const ProblemTableRows: FC<ProblemTableRowsProps> = ({ items, loading, er
                         <ProblemStatusIcon status={item.status} />
                     </TableCell>
                     <TableCell>
-                        <Chip
-                            label={item.bookSlug}
-                            size="small"
-                            variant="outlined"
-                            color="primary"
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                onBookSlugClick(item.bookSlug);
-                            }}
-                        />
+                        <BookChip bookSlug={item.bookSlug} onClick={onBookSlugClick} />
                     </TableCell>
                     <TableCell>
                         {item.code}
                         {item.isHard ? "*" : ""}
                     </TableCell>
-                    <TableCell>
+                    <TableCell sx={columnVisibility[3]}>
                         <Stack direction={{ xs: "column", md: "row" }} spacing={{ xs: 0.5, md: 1 }}>
                             {item.tags.map((tag) => (
                                 <TagChip key={`${item.key}-${tag}`} label={tag} />
                             ))}
                         </Stack>
                     </TableCell>
+                    <TableCell sx={columnVisibility[4]}>{formatRelative(item.createdAt)}</TableCell>
                 </TableRow>
             ))}
         </>

--- a/edukate-frontend/src/features/problems/components/table/ProblemTableToolbar.tsx
+++ b/edukate-frontend/src/features/problems/components/table/ProblemTableToolbar.tsx
@@ -1,21 +1,11 @@
 import { FC, ReactNode } from "react";
-import {
-    Toolbar,
-    Box,
-    TextField,
-    FormControl,
-    InputLabel,
-    Select,
-    MenuItem,
-    FormControlLabel,
-    Checkbox,
-    Chip,
-} from "@mui/material";
+import { Box, FormControl, InputLabel, Select, MenuItem, FormControlLabel, Checkbox, Stack } from "@mui/material";
 import DoneIcon from "@mui/icons-material/DoneOutlined";
 import CloseIcon from "@mui/icons-material/CloseOutlined";
 import PendingIcon from "@mui/icons-material/PendingOutlined";
 import { useAuthContext } from "@/features/auth/context";
 import { ProblemStatus } from "@/features/problems/types";
+import { ClearableTextField } from "@/shared/components/ClearableTextField";
 
 export type StatusFilter = ProblemStatus | "ALL" | undefined;
 type DifficultyFilter = boolean | undefined;
@@ -65,75 +55,104 @@ export const ProblemTableToolbar: FC<Props> = ({
 }) => {
     const { isAuthorized } = useAuthContext();
     return (
-        <Box>
-            <Toolbar sx={{ display: "flex", gap: 2, justifyContent: "space-between", flexWrap: "wrap" }}>
-                <Box sx={{ display: "flex", gap: 2, alignItems: "center", flexWrap: "wrap" }}>
-                    <TextField
-                        label="Search by prefix"
-                        size="small"
-                        value={prefix}
-                        onChange={(e) => {
-                            onPrefixChange(e.target.value);
-                        }}
-                    />
+        <Box sx={{ position: "relative" }}>
+            {rightSlot && <Box sx={{ position: "absolute", top: 8, right: 8 }}>{rightSlot}</Box>}
+            <Stack
+                direction="column"
+                spacing={2}
+                sx={{
+                    px: { xs: 1, md: 2 },
+                    pt: 1,
+                }}
+            >
+                {/* Row 1 on lg+: all four inputs. On xs/sm/md: book+code on one row, selectors on another */}
+                <Stack direction={{ xs: "column", lg: "row" }} spacing={2} sx={{ alignItems: { lg: "center" } }}>
+                    <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+                        <ClearableTextField
+                            label="Book"
+                            value={bookSlug ?? ""}
+                            onChange={(v) => {
+                                onBookSlugChange(v || undefined);
+                            }}
+                            onClear={() => {
+                                onBookSlugChange(undefined);
+                            }}
+                            sx={{ minWidth: { md: 120 }, flex: { xs: "1 1 0", md: "0 1 auto" } }}
+                        />
 
-                    {isAuthorized && (
-                        <FormControl size="small" sx={{ minWidth: 160 }}>
-                            <InputLabel size={"small"} id="status-filter-label">
-                                Status
+                        <ClearableTextField
+                            label="Problem code"
+                            value={prefix}
+                            onChange={onPrefixChange}
+                            onClear={() => {
+                                onPrefixChange("");
+                            }}
+                            sx={{ minWidth: { md: 140 }, flex: { xs: "1 1 0", md: "0 1 auto" } }}
+                        />
+                    </Stack>
+
+                    <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+                        {isAuthorized && (
+                            <FormControl size="small" sx={{ minWidth: { md: 160 }, flex: { xs: "1 1 0", md: "0 1 auto" } }}>
+                                <InputLabel size={"small"} id="status-filter-label">
+                                    Status
+                                </InputLabel>
+                                <Select
+                                    labelId="status-filter-label"
+                                    size={"small"}
+                                    label="Status"
+                                    value={status ?? "ALL"}
+                                    onChange={(e) => {
+                                        onStatusChange((e.target.value || "ALL") as StatusFilter);
+                                    }}
+                                >
+                                    <MenuItem value="ALL">All</MenuItem>
+                                    <MenuItem value="SOLVED">
+                                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                            <DoneIcon color="success" fontSize="small" />
+                                            Solved
+                                        </Box>
+                                    </MenuItem>
+                                    <MenuItem value="SOLVING">
+                                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                            <PendingIcon color="warning" fontSize="small" />
+                                            Solving
+                                        </Box>
+                                    </MenuItem>
+                                    <MenuItem value="FAILED">
+                                        <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                            <CloseIcon color="error" fontSize="small" />
+                                            Failed
+                                        </Box>
+                                    </MenuItem>
+                                    <MenuItem value="NOT_SOLVED">Not solved</MenuItem>
+                                </Select>
+                            </FormControl>
+                        )}
+
+                        <FormControl size="small" sx={{ minWidth: { md: 130 }, flex: { xs: "1 1 0", md: "0 1 auto" } }}>
+                            <InputLabel size={"small"} id="difficulty-filter-label">
+                                Difficulty
                             </InputLabel>
                             <Select
-                                labelId="status-filter-label"
+                                labelId="difficulty-filter-label"
                                 size={"small"}
-                                label="Status"
-                                value={status ?? "ALL"}
+                                label="Difficulty"
+                                value={difficultyToSelectValue(isHard)}
                                 onChange={(e) => {
-                                    onStatusChange((e.target.value || "ALL") as StatusFilter);
+                                    onIsHardChange(selectValueToDifficulty(e.target.value));
                                 }}
                             >
-                                <MenuItem value="ALL">All</MenuItem>
-                                <MenuItem value="SOLVED">
-                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                        <DoneIcon color="success" fontSize="small" />
-                                        Solved
-                                    </Box>
-                                </MenuItem>
-                                <MenuItem value="SOLVING">
-                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                        <PendingIcon color="warning" fontSize="small" />
-                                        Solving
-                                    </Box>
-                                </MenuItem>
-                                <MenuItem value="FAILED">
-                                    <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                        <CloseIcon color="error" fontSize="small" />
-                                        Failed
-                                    </Box>
-                                </MenuItem>
-                                <MenuItem value="NOT_SOLVED">Not solved</MenuItem>
+                                <MenuItem value="ANY">Any</MenuItem>
+                                <MenuItem value="HARD">Hard</MenuItem>
+                                <MenuItem value="MEDIUM">Medium</MenuItem>
                             </Select>
                         </FormControl>
-                    )}
+                    </Stack>
+                </Stack>
 
-                    <FormControl size="small" sx={{ minWidth: 130 }}>
-                        <InputLabel size={"small"} id="difficulty-filter-label">
-                            Difficulty
-                        </InputLabel>
-                        <Select
-                            labelId="difficulty-filter-label"
-                            size={"small"}
-                            label="Difficulty"
-                            value={difficultyToSelectValue(isHard)}
-                            onChange={(e) => {
-                                onIsHardChange(selectValueToDifficulty(e.target.value));
-                            }}
-                        >
-                            <MenuItem value="ANY">Any</MenuItem>
-                            <MenuItem value="HARD">Hard</MenuItem>
-                            <MenuItem value="MEDIUM">Medium</MenuItem>
-                        </Select>
-                    </FormControl>
-
+                {/* Checkboxes — always on their own row */}
+                <Stack direction="row" spacing={1} sx={{ alignItems: "center" }}>
                     <FormControlLabel
                         control={
                             <Checkbox
@@ -141,9 +160,11 @@ export const ProblemTableToolbar: FC<Props> = ({
                                 onChange={(e) => {
                                     onHasPicturesChange(e.target.checked);
                                 }}
+                                size="small"
                             />
                         }
                         label="With pictures"
+                        sx={{ mr: 0 }}
                     />
 
                     <FormControlLabel
@@ -153,28 +174,14 @@ export const ProblemTableToolbar: FC<Props> = ({
                                 onChange={(e) => {
                                     onHasResultChange(e.target.checked);
                                 }}
+                                size="small"
                             />
                         }
                         label="With answer"
+                        sx={{ mr: 0 }}
                     />
-                </Box>
-
-                <Box sx={{ marginLeft: "auto" }}>{rightSlot}</Box>
-            </Toolbar>
-
-            {bookSlug && (
-                <Box sx={{ px: 3, pb: 1, display: "flex", justifyContent: "flex-start" }}>
-                    <Chip
-                        label={`Book: ${bookSlug}`}
-                        onDelete={() => {
-                            onBookSlugChange(undefined);
-                        }}
-                        color="primary"
-                        variant="outlined"
-                        size="small"
-                    />
-                </Box>
-            )}
+                </Stack>
+            </Stack>
         </Box>
     );
 };

--- a/edukate-frontend/src/features/problems/components/table/RandomProblemButton.tsx
+++ b/edukate-frontend/src/features/problems/components/table/RandomProblemButton.tsx
@@ -1,11 +1,11 @@
 import { FC } from "react";
 import { useRandomProblemKeyQuery } from "@/features/problems/api";
 import { useNavigate } from "react-router-dom";
-import { IconButton, Tooltip } from "@mui/material";
+import { Fab, IconButton, Tooltip } from "@mui/material";
 import ShuffleIcon from "@mui/icons-material/Shuffle";
 import { toast } from "react-toastify";
 
-export const RandomProblemButton: FC = () => {
+function useRandomProblemNavigation() {
     const randomProblemQuery = useRandomProblemKeyQuery();
     const navigate = useNavigate();
     const onClick = () => {
@@ -19,6 +19,11 @@ export const RandomProblemButton: FC = () => {
             },
         );
     };
+    return onClick;
+}
+
+export const RandomProblemButton: FC = () => {
+    const onClick = useRandomProblemNavigation();
 
     return (
         <Tooltip title={"Randomize problem"}>
@@ -26,5 +31,15 @@ export const RandomProblemButton: FC = () => {
                 <ShuffleIcon sx={{ fontSize: 30 }} />
             </IconButton>
         </Tooltip>
+    );
+};
+
+export const RandomProblemFab: FC = () => {
+    const onClick = useRandomProblemNavigation();
+
+    return (
+        <Fab color="primary" aria-label="random-problem" onClick={onClick} sx={{ position: "fixed", bottom: 24, right: 24 }}>
+            <ShuffleIcon />
+        </Fab>
     );
 };

--- a/edukate-frontend/src/features/submissions/components/SubmissionListComponent.test.tsx
+++ b/edukate-frontend/src/features/submissions/components/SubmissionListComponent.test.tsx
@@ -55,6 +55,8 @@ it("renders table with correct column headers", async () => {
     render(<SubmissionListComponent />);
 
     await waitFor(() => {
+        // "Book" appears both as a column header and toolbar label
+        expect(screen.getAllByText("Book").length).toBeGreaterThanOrEqual(2);
         expect(screen.getByText("Problem")).toBeInTheDocument();
         expect(screen.getByText("User")).toBeInTheDocument();
         expect(screen.getByText("Updated")).toBeInTheDocument();
@@ -67,8 +69,8 @@ it("renders submission rows from API response", async () => {
     render(<SubmissionListComponent />);
 
     await waitFor(() => {
-        expect(screen.getByText("savchenko/1.1.1")).toBeInTheDocument();
-        expect(screen.getByText("savchenko/1.1.2")).toBeInTheDocument();
+        expect(screen.getByText("1.1.1")).toBeInTheDocument();
+        expect(screen.getByText("1.1.2")).toBeInTheDocument();
         expect(screen.getByText("testuser")).toBeInTheDocument();
         expect(screen.getByText("alice")).toBeInTheDocument();
     });
@@ -93,10 +95,10 @@ it("opens submission drawer when a row is clicked", async () => {
     render(<SubmissionListComponent />);
 
     await waitFor(() => {
-        expect(screen.getByText("savchenko/1.1.1")).toBeInTheDocument();
+        expect(screen.getByText("1.1.1")).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByText("savchenko/1.1.1"));
+    await userEvent.click(screen.getByText("1.1.1"));
 
     await waitFor(() => {
         expect(screen.getByText("Submission #1")).toBeInTheDocument();
@@ -117,7 +119,9 @@ it("renders empty state when no submissions", async () => {
     render(<SubmissionListComponent />);
 
     await waitFor(() => {
-        expect(screen.getByText("0–0 of 0 submissions")).toBeInTheDocument();
+        expect(
+            screen.getByText((_, el) => el !== null && el.tagName === "P" && el.textContent === "0–0 of 0 submissions"),
+        ).toBeInTheDocument();
     });
 });
 
@@ -127,7 +131,11 @@ it("displays pagination info", async () => {
     render(<SubmissionListComponent />);
 
     await waitFor(() => {
-        expect(screen.getByText((content) => content.includes("of 2 submissions"))).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                (_, el) => el !== null && el.tagName === "P" && (el.textContent?.includes("of 2 submissions") ?? false),
+            ),
+        ).toBeInTheDocument();
     });
 });
 

--- a/edukate-frontend/src/features/submissions/components/SubmissionListComponent.tsx
+++ b/edukate-frontend/src/features/submissions/components/SubmissionListComponent.tsx
@@ -33,7 +33,7 @@ export default function SubmissionListComponent() {
     return (
         <Box>
             <SubmissionTable
-                headerCells={["", "Problem", "User", "Updated"]}
+                headerCells={["", "Book", "Problem", "User", "Updated"]}
                 toolbar={
                     <SubmissionTableToolbar
                         status={status}
@@ -62,6 +62,8 @@ export default function SubmissionListComponent() {
                     loading={isLoading}
                     error={error}
                     onRowClick={setSelectedSubmission}
+                    onBookSlugClick={handlers.onChangeBookSlug}
+                    onUserNameClick={handlers.onChangeUserName}
                 />
             </SubmissionTable>
             <SubmissionDrawer

--- a/edukate-frontend/src/features/submissions/components/table/SubmissionTable.tsx
+++ b/edukate-frontend/src/features/submissions/components/table/SubmissionTable.tsx
@@ -8,6 +8,12 @@ type SubmissionTableProps = {
     footer?: ReactNode;
 };
 
+const headerTableCellSx = { minWidth: 44, maxWidth: 44, width: 44, p: 0.5 } as const;
+/** Per-column responsive visibility: Updated (4) hidden below md */
+const columnVisibility: Record<number, object> = {
+    4: { display: { xs: "none", md: "table-cell" } },
+};
+
 export const SubmissionTable: FC<SubmissionTableProps> = ({ headerCells, toolbar, children, footer }) => {
     return (
         <TableContainer component={Paper} sx={{ borderRadius: 3, overflow: "hidden" }}>
@@ -19,7 +25,10 @@ export const SubmissionTable: FC<SubmissionTableProps> = ({ headerCells, toolbar
                             <TableCell
                                 key={`header-${String(i)}`}
                                 align={i === 0 ? "center" : undefined}
-                                sx={i === 0 ? { minWidth: 44, maxWidth: 44, width: 44, p: 0.5 } : undefined}
+                                sx={{
+                                    ...(i === 0 ? headerTableCellSx : {}),
+                                    ...columnVisibility[i],
+                                }}
                             >
                                 {h}
                             </TableCell>

--- a/edukate-frontend/src/features/submissions/components/table/SubmissionTablePagination.tsx
+++ b/edukate-frontend/src/features/submissions/components/table/SubmissionTablePagination.tsx
@@ -25,10 +25,10 @@ export const SubmissionTablePagination: FC<Props> = ({
     return (
         <TableFooter>
             <TableRow>
-                <TableCell colSpan={4} sx={{ py: 1 }}>
+                <TableCell colSpan={5} sx={{ py: 1 }}>
                     <Box sx={{ display: "flex", alignItems: "center" }}>
                         <Box sx={{ flex: 1, display: "flex", alignItems: "center", gap: 1 }}>
-                            <Typography variant="body2" color="text.secondary">
+                            <Typography variant="body2" color="text.secondary" sx={{ display: { xs: "none", md: "block" } }}>
                                 Rows per page:
                             </Typography>
                             <Select
@@ -57,7 +57,11 @@ export const SubmissionTablePagination: FC<Props> = ({
 
                         <Box sx={{ flex: 1, display: "flex", justifyContent: "flex-end" }}>
                             <Typography variant="body2" color="text.secondary">
-                                {from}–{to} of {count} submissions
+                                {from}–{to} of {count}
+                                <Box component="span" sx={{ display: { xs: "none", md: "inline" } }}>
+                                    {" "}
+                                    submissions
+                                </Box>
                             </Typography>
                         </Box>
                     </Box>

--- a/edukate-frontend/src/features/submissions/components/table/SubmissionTableRows.tsx
+++ b/edukate-frontend/src/features/submissions/components/table/SubmissionTableRows.tsx
@@ -1,50 +1,66 @@
 import { FC } from "react";
-import { TableRow, TableCell, Skeleton, Chip } from "@mui/material";
+import { TableRow, TableCell, Skeleton, Box, Tooltip, SxProps, Theme } from "@mui/material";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
 import { Submission, SubmissionStatus } from "@/features/submissions/types";
 import { formatRelative } from "@/shared/utils/date";
+import { BookChip } from "@/shared/components/BookChip";
+import { defaultTooltipSlotProps } from "@/shared/utils/utils";
 
 type SubmissionTableRowsProps = {
     items: Submission[] | undefined;
     loading: boolean;
     error: unknown;
     onRowClick: (submission: Submission) => void;
+    onBookSlugClick: (bookSlug: string) => void;
+    onUserNameClick: (userName: string) => void;
 };
 
-function statusIcon(status: SubmissionStatus) {
+function SubmissionStatusIcon({ status }: { status: SubmissionStatus }) {
     switch (status) {
         case "SUCCESS":
-            return <CheckCircleOutlineIcon color="success" fontSize="small" />;
+            return (
+                <Tooltip title="Success" slotProps={defaultTooltipSlotProps}>
+                    <CheckCircleOutlineIcon color="success" />
+                </Tooltip>
+            );
         case "PENDING":
-            return <HourglassEmptyIcon color="warning" fontSize="small" />;
+            return (
+                <Tooltip title="Pending" slotProps={defaultTooltipSlotProps}>
+                    <HourglassEmptyIcon color="warning" />
+                </Tooltip>
+            );
         case "FAILED":
-            return <CancelOutlinedIcon color="error" fontSize="small" />;
+            return (
+                <Tooltip title="Failed" slotProps={defaultTooltipSlotProps}>
+                    <CancelOutlinedIcon color="error" />
+                </Tooltip>
+            );
     }
 }
 
-function statusLabel(status: SubmissionStatus): string {
-    switch (status) {
-        case "SUCCESS":
-            return "Success";
-        case "PENDING":
-            return "Pending";
-        case "FAILED":
-            return "Failed";
-    }
-}
+const COLUMN_COUNT = 5;
+/** Per-column responsive visibility: Updated (4) hidden below md */
+const columnVisibility: Record<number, SxProps<Theme>> = {
+    4: { display: { xs: "none", md: "table-cell" } },
+};
 
-const COLUMN_COUNT = 4;
-
-export const SubmissionTableRows: FC<SubmissionTableRowsProps> = ({ items, loading, error, onRowClick }) => {
+export const SubmissionTableRows: FC<SubmissionTableRowsProps> = ({
+    items,
+    loading,
+    error,
+    onRowClick,
+    onBookSlugClick,
+    onUserNameClick,
+}) => {
     if (loading || error) {
         return (
             <>
                 {Array.from({ length: 5 }).map((_, i) => (
                     <TableRow key={`placeholder-${String(i)}`}>
                         {Array.from({ length: COLUMN_COUNT }).map((_, j) => (
-                            <TableCell key={`cell-${String(j)}`}>
+                            <TableCell key={`cell-${String(j)}`} sx={columnVisibility[j]}>
                                 <Skeleton variant="rounded" />
                             </TableCell>
                         ))}
@@ -70,11 +86,31 @@ export const SubmissionTableRows: FC<SubmissionTableRowsProps> = ({ items, loadi
                     }}
                 >
                     <TableCell align="center">
-                        <Chip icon={statusIcon(item.status)} label={statusLabel(item.status)} size="small" />
+                        <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center" }}>
+                            <SubmissionStatusIcon status={item.status} />
+                        </Box>
                     </TableCell>
-                    <TableCell>{item.problemKey}</TableCell>
-                    <TableCell>{item.userName}</TableCell>
-                    <TableCell>{formatRelative(item.updatedAt)}</TableCell>
+                    <TableCell>
+                        <BookChip bookSlug={item.problemKey.split("/")[0]} onClick={onBookSlugClick} />
+                    </TableCell>
+                    <TableCell>{item.problemKey.split("/").slice(1).join("/")}</TableCell>
+                    <TableCell>
+                        <Box
+                            component="span"
+                            sx={{
+                                color: "primary.main",
+                                cursor: "pointer",
+                                "&:hover": { textDecoration: "underline" },
+                            }}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onUserNameClick(item.userName);
+                            }}
+                        >
+                            {item.userName}
+                        </Box>
+                    </TableCell>
+                    <TableCell sx={columnVisibility[4]}>{formatRelative(item.updatedAt)}</TableCell>
                 </TableRow>
             ))}
         </>

--- a/edukate-frontend/src/features/submissions/components/table/SubmissionTableToolbar.tsx
+++ b/edukate-frontend/src/features/submissions/components/table/SubmissionTableToolbar.tsx
@@ -1,6 +1,7 @@
 import { FC } from "react";
-import { Toolbar, Box, TextField, FormControl, InputLabel, Select, MenuItem } from "@mui/material";
+import { Box, FormControl, InputLabel, Select, MenuItem, Stack } from "@mui/material";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutline";
+import { ClearableTextField } from "@/shared/components/ClearableTextField";
 import HourglassEmptyIcon from "@mui/icons-material/HourglassEmpty";
 import CancelOutlinedIcon from "@mui/icons-material/CancelOutlined";
 import { StatusFilter } from "@/features/submissions/hooks/useSubmissionTableParams";
@@ -28,69 +29,80 @@ export const SubmissionTableToolbar: FC<Props> = ({
 }) => {
     return (
         <Box>
-            <Toolbar sx={{ display: "flex", gap: 2, justifyContent: "flex-start", flexWrap: "wrap" }}>
-                <TextField
-                    label="Username"
-                    size="small"
-                    value={userName}
-                    onChange={(e) => {
-                        onUserNameChange(e.target.value);
-                    }}
-                />
-
-                <TextField
-                    label="Book"
-                    size="small"
-                    value={bookSlug}
-                    onChange={(e) => {
-                        onBookSlugChange(e.target.value);
-                    }}
-                />
-
-                <TextField
-                    label="Problem code"
-                    size="small"
-                    value={problemCode}
-                    onChange={(e) => {
-                        onProblemCodeChange(e.target.value);
-                    }}
-                />
-
-                <FormControl size="small" sx={{ minWidth: 160 }}>
-                    <InputLabel size="small" id="submission-status-filter-label">
-                        Status
-                    </InputLabel>
-                    <Select
-                        labelId="submission-status-filter-label"
-                        size="small"
-                        label="Status"
-                        value={status ?? "ALL"}
-                        onChange={(e) => {
-                            onStatusChange((e.target.value || "ALL") as StatusFilter);
+            <Stack
+                direction={{ xs: "column", md: "row" }}
+                spacing={2}
+                sx={{ px: { xs: 1, md: 2 }, pt: 1, alignItems: { md: "center" }, flexWrap: "wrap" }}
+            >
+                <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+                    <ClearableTextField
+                        label="Username"
+                        value={userName}
+                        onChange={onUserNameChange}
+                        onClear={() => {
+                            onUserNameChange("");
                         }}
-                    >
-                        <MenuItem value="ALL">All</MenuItem>
-                        <MenuItem value="SUCCESS">
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                <CheckCircleOutlineIcon color="success" fontSize="small" />
-                                Success
-                            </Box>
-                        </MenuItem>
-                        <MenuItem value="PENDING">
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                <HourglassEmptyIcon color="warning" fontSize="small" />
-                                Pending
-                            </Box>
-                        </MenuItem>
-                        <MenuItem value="FAILED">
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
-                                <CancelOutlinedIcon color="error" fontSize="small" />
-                                Failed
-                            </Box>
-                        </MenuItem>
-                    </Select>
-                </FormControl>
-            </Toolbar>
+                        sx={{ minWidth: { md: 140 }, flex: { xs: "1 1 0", md: "0 1 auto" } }}
+                    />
+
+                    <FormControl size="small" sx={{ minWidth: { md: 160 }, flex: { xs: "1 1 0", md: "0 1 auto" } }}>
+                        <InputLabel size="small" id="submission-status-filter-label">
+                            Status
+                        </InputLabel>
+                        <Select
+                            labelId="submission-status-filter-label"
+                            size="small"
+                            label="Status"
+                            value={status ?? "ALL"}
+                            onChange={(e) => {
+                                onStatusChange((e.target.value || "ALL") as StatusFilter);
+                            }}
+                        >
+                            <MenuItem value="ALL">All</MenuItem>
+                            <MenuItem value="SUCCESS">
+                                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                    <CheckCircleOutlineIcon color="success" fontSize="small" />
+                                    Success
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="PENDING">
+                                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                    <HourglassEmptyIcon color="warning" fontSize="small" />
+                                    Pending
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="FAILED">
+                                <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                                    <CancelOutlinedIcon color="error" fontSize="small" />
+                                    Failed
+                                </Box>
+                            </MenuItem>
+                        </Select>
+                    </FormControl>
+                </Stack>
+
+                <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
+                    <ClearableTextField
+                        label="Book"
+                        value={bookSlug}
+                        onChange={onBookSlugChange}
+                        onClear={() => {
+                            onBookSlugChange("");
+                        }}
+                        sx={{ minWidth: { md: 120 }, flexGrow: { xs: 1, md: 0 } }}
+                    />
+
+                    <ClearableTextField
+                        label="Problem code"
+                        value={problemCode}
+                        onChange={onProblemCodeChange}
+                        onClear={() => {
+                            onProblemCodeChange("");
+                        }}
+                        sx={{ minWidth: { md: 140 }, flexGrow: { xs: 1, md: 0 } }}
+                    />
+                </Stack>
+            </Stack>
         </Box>
     );
 };

--- a/edukate-frontend/src/main.tsx
+++ b/edukate-frontend/src/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
+import "./pwa";
 import "./App.css";
 import App from "./app/App";
 

--- a/edukate-frontend/src/pages/ProblemListPage.test.tsx
+++ b/edukate-frontend/src/pages/ProblemListPage.test.tsx
@@ -25,6 +25,7 @@ describe("ProblemListPage", () => {
                     isHard: false,
                     tags: ["algebra"],
                     status: "NOT_SOLVED",
+                    createdAt: "2026-01-01T00:00:00Z",
                 },
             ]),
             getCountMockHandler(1),

--- a/edukate-frontend/src/pwa.ts
+++ b/edukate-frontend/src/pwa.ts
@@ -1,0 +1,12 @@
+import { registerSW } from "virtual:pwa-register";
+
+const updateSW = registerSW({
+    onNeedRefresh() {
+        window.dispatchEvent(new CustomEvent("sw-update-available"));
+    },
+    onOfflineReady() {
+        console.log("Edukate is ready for offline use.");
+    },
+});
+
+(window as unknown as { __updateSW: typeof updateSW }).__updateSW = updateSW;

--- a/edukate-frontend/src/shared/components/BookChip.test.tsx
+++ b/edukate-frontend/src/shared/components/BookChip.test.tsx
@@ -1,0 +1,46 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test/render";
+import { BookChip } from "./BookChip";
+
+describe("BookChip", () => {
+    it("renders the book slug as text", () => {
+        render(<BookChip bookSlug="savchenko" />);
+        expect(screen.getByText("savchenko")).toBeInTheDocument();
+    });
+
+    it("applies primary color to the text", () => {
+        render(<BookChip bookSlug="savchenko" />);
+        const el = screen.getByText("savchenko");
+        expect(el).toBeInTheDocument();
+    });
+
+    it("calls onClick with the book slug when clicked", async () => {
+        const onClick = vi.fn();
+        render(<BookChip bookSlug="savchenko" onClick={onClick} />);
+        await userEvent.click(screen.getByText("savchenko"));
+        expect(onClick).toHaveBeenCalledWith("savchenko");
+    });
+
+    it("shows pointer cursor when onClick is provided", () => {
+        render(<BookChip bookSlug="savchenko" onClick={vi.fn()} />);
+        expect(screen.getByText("savchenko")).toHaveStyle({ cursor: "pointer" });
+    });
+
+    it("shows default cursor when onClick is not provided", () => {
+        render(<BookChip bookSlug="savchenko" />);
+        expect(screen.getByText("savchenko")).toHaveStyle({ cursor: "default" });
+    });
+
+    it("stops event propagation on click to prevent row click", async () => {
+        const rowClick = vi.fn();
+        const chipClick = vi.fn();
+        render(
+            <div onClick={rowClick}>
+                <BookChip bookSlug="savchenko" onClick={chipClick} />
+            </div>,
+        );
+        await userEvent.click(screen.getByText("savchenko"));
+        expect(chipClick).toHaveBeenCalledOnce();
+        expect(rowClick).not.toHaveBeenCalled();
+    });
+});

--- a/edukate-frontend/src/shared/components/BookChip.tsx
+++ b/edukate-frontend/src/shared/components/BookChip.tsx
@@ -1,0 +1,30 @@
+import { FC } from "react";
+import { Box } from "@mui/material";
+
+type BookChipProps = {
+    bookSlug: string;
+    onClick?: (bookSlug: string) => void;
+};
+
+export const BookChip: FC<BookChipProps> = ({ bookSlug, onClick }) => {
+    return (
+        <Box
+            component="span"
+            sx={{
+                color: "primary.main",
+                cursor: onClick ? "pointer" : "default",
+                "&:hover": onClick ? { textDecoration: "underline" } : undefined,
+            }}
+            onClick={
+                onClick
+                    ? (e) => {
+                          e.stopPropagation();
+                          onClick(bookSlug);
+                      }
+                    : undefined
+            }
+        >
+            {bookSlug}
+        </Box>
+    );
+};

--- a/edukate-frontend/src/shared/components/BookFilterChip.tsx
+++ b/edukate-frontend/src/shared/components/BookFilterChip.tsx
@@ -1,0 +1,17 @@
+import { FC } from "react";
+import { Box, Chip } from "@mui/material";
+
+type BookFilterChipProps = {
+    bookSlug: string;
+    onClear: () => void;
+};
+
+export const BookFilterChip: FC<BookFilterChipProps> = ({ bookSlug, onClear }) => {
+    if (!bookSlug) return null;
+
+    return (
+        <Box sx={{ px: 2, pt: 1, pb: 1, display: "flex", justifyContent: "flex-start" }}>
+            <Chip label={`Book: ${bookSlug}`} onDelete={onClear} color="primary" variant="outlined" size="small" />
+        </Box>
+    );
+};

--- a/edukate-frontend/src/shared/components/ClearableTextField.test.tsx
+++ b/edukate-frontend/src/shared/components/ClearableTextField.test.tsx
@@ -1,0 +1,35 @@
+import userEvent from "@testing-library/user-event";
+import { render, screen } from "@/test/render";
+import { ClearableTextField } from "./ClearableTextField";
+
+describe("ClearableTextField", () => {
+    it("renders the label and value", () => {
+        render(<ClearableTextField label="Book" value="savchenko" onChange={vi.fn()} onClear={vi.fn()} />);
+        expect(screen.getByLabelText("Book")).toHaveValue("savchenko");
+    });
+
+    it("always renders the clear button in the DOM to prevent layout shift", () => {
+        render(<ClearableTextField label="Book" value="" onChange={vi.fn()} onClear={vi.fn()} />);
+        // Button is always present (reserving space), even when value is empty
+        expect(screen.getByTestId("ClearIcon")).toBeInTheDocument();
+    });
+
+    it("calls onClear when the clear button is clicked", async () => {
+        const onClear = vi.fn();
+        render(<ClearableTextField label="Book" value="savchenko" onChange={vi.fn()} onClear={onClear} />);
+        await userEvent.click(screen.getByRole("button"));
+        expect(onClear).toHaveBeenCalledOnce();
+    });
+
+    it("calls onChange when user types", async () => {
+        const onChange = vi.fn();
+        render(<ClearableTextField label="Book" value="" onChange={onChange} onClear={vi.fn()} />);
+        await userEvent.type(screen.getByLabelText("Book"), "s");
+        expect(onChange).toHaveBeenCalledWith("s");
+    });
+
+    it("applies custom sx prop", () => {
+        render(<ClearableTextField label="Book" value="" onChange={vi.fn()} onClear={vi.fn()} sx={{ minWidth: 200 }} />);
+        expect(screen.getByLabelText("Book")).toBeInTheDocument();
+    });
+});

--- a/edukate-frontend/src/shared/components/ClearableTextField.tsx
+++ b/edukate-frontend/src/shared/components/ClearableTextField.tsx
@@ -1,0 +1,37 @@
+import { FC } from "react";
+import { TextField, IconButton, InputAdornment } from "@mui/material";
+import ClearIcon from "@mui/icons-material/Clear";
+import type { SxProps, Theme } from "@mui/material";
+
+type ClearableTextFieldProps = {
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    onClear: () => void;
+    sx?: SxProps<Theme>;
+};
+
+export const ClearableTextField: FC<ClearableTextFieldProps> = ({ label, value, onChange, onClear, sx }) => {
+    return (
+        <TextField
+            label={label}
+            size="small"
+            value={value}
+            onChange={(e) => {
+                onChange(e.target.value);
+            }}
+            sx={sx}
+            slotProps={{
+                input: {
+                    endAdornment: (
+                        <InputAdornment position="end">
+                            <IconButton size="small" onClick={onClear} sx={{ visibility: value ? "visible" : "hidden" }}>
+                                <ClearIcon fontSize="small" />
+                            </IconButton>
+                        </InputAdornment>
+                    ),
+                },
+            }}
+        />
+    );
+};

--- a/edukate-frontend/src/shared/components/images/ImageLightbox.tsx
+++ b/edukate-frontend/src/shared/components/images/ImageLightbox.tsx
@@ -47,7 +47,7 @@ export const ImageLightbox: FC<ImageLightboxProps> = ({ images, index, open, onC
             }}
             // Lightbox backdrop — intentionally hardcoded (YARL styles prop doesn't support theme tokens)
             styles={{ container: { backgroundColor: "rgba(0, 0, 0, 0.75)" } }}
-            controller={{ closeOnBackdropClick: true }}
+            controller={{ closeOnBackdropClick: true, closeOnPullDown: true }}
         />
     );
 };

--- a/edukate-frontend/src/shared/components/images/ImageList.tsx
+++ b/edukate-frontend/src/shared/components/images/ImageList.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Container, ImageList, ImageListItem } from "@mui/material";
 import { ImageLightbox } from "./ImageLightbox";
+import { useDeviceContext } from "@/shared/context/DeviceContext";
 
 const imageListItemSx = {
     justifyContent: "center",
@@ -17,10 +18,11 @@ interface ImageListComponentProps {
 
 export function ImageListComponent({ images }: ImageListComponentProps) {
     const [selectedIndex, setSelectedIndex] = useState<number>(-1);
+    const { isMobile } = useDeviceContext();
 
     return (
         <Container sx={containerSx}>
-            <ImageList gap={3} cols={images.length} variant="woven">
+            <ImageList gap={3} cols={isMobile ? 1 : Math.min(images.length, 3)} variant="woven">
                 {images.map((imageUrl, index) => (
                     <ImageListItem
                         key={imageUrl}
@@ -38,7 +40,7 @@ export function ImageListComponent({ images }: ImageListComponentProps) {
                             srcSet={imageUrl}
                             alt={`Image ${String(index + 1)}`}
                             loading="lazy"
-                            style={{ maxWidth: "25rem" }}
+                            style={{ maxWidth: isMobile ? "90vw" : "25rem" }}
                         />
                     </ImageListItem>
                 ))}

--- a/edukate-frontend/src/shared/components/layout/PageSkeleton.tsx
+++ b/edukate-frontend/src/shared/components/layout/PageSkeleton.tsx
@@ -6,6 +6,9 @@ import { lazy, Suspense, useEffect } from "react";
 import { toast } from "react-toastify";
 import { AppFooter } from "./AppFooter";
 import { ErrorBoundary, FallbackProps } from "react-error-boundary";
+import { OfflineBanner } from "@/shared/components/pwa/OfflineBanner";
+import { InstallPrompt } from "@/shared/components/pwa/InstallPrompt";
+import { UpdatePrompt } from "@/shared/components/pwa/UpdatePrompt";
 
 const ParticlesComponent = lazy(() => import("@/shared/components/Particles"));
 
@@ -34,8 +37,9 @@ export default function PageSkeleton() {
 
     return (
         <Box>
+            <OfflineBanner />
             <EdukateTopBar />
-            <Container maxWidth={"lg"} sx={{ pt: { xs: "80px", md: "120px" }, pb: "2rem" }}>
+            <Container maxWidth={"lg"} sx={{ pt: "120px", pb: "2rem" }}>
                 <ErrorBoundary FallbackComponent={RouteFallback}>
                     <Suspense
                         fallback={
@@ -52,6 +56,8 @@ export default function PageSkeleton() {
                 </Suspense>
             </Container>
             <AppFooter />
+            <InstallPrompt />
+            <UpdatePrompt />
         </Box>
     );
 }

--- a/edukate-frontend/src/shared/components/layout/topbar/EdukateTopBar.tsx
+++ b/edukate-frontend/src/shared/components/layout/topbar/EdukateTopBar.tsx
@@ -34,7 +34,7 @@ export function EdukateTopBar() {
     const { pathname } = useLocation();
     const isSignUpPage = pathname === "/sign-up";
     const isSignInPage = pathname === "/sign-in";
-    const isNavActive = (href: string) => pathname === href || pathname.startsWith(href + "/");
+    const isNavActive = (href: string) => pathname === href;
     return (
         <AppBar position="fixed" enableColorOnDark sx={appBarSx}>
             <Container maxWidth="lg">
@@ -74,7 +74,7 @@ export function EdukateTopBar() {
                                 <UserMenu />
                             </Box>
                         ) : (
-                            <Box sx={{ display: "flex", gap: 1, alignItems: "center" }}>
+                            <Box sx={{ display: { xs: "none", md: "flex" }, gap: 1, alignItems: "center" }}>
                                 <TopBarLink
                                     text={"Sign In"}
                                     onClick={() => {

--- a/edukate-frontend/src/shared/components/layout/topbar/MobileDrawer.tsx
+++ b/edukate-frontend/src/shared/components/layout/topbar/MobileDrawer.tsx
@@ -1,8 +1,11 @@
 import { FC } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { Box, Divider, Drawer, List, ListItem, ListItemButton, ListItemIcon, ListItemText } from "@mui/material";
+import LoginOutlined from "@mui/icons-material/LoginOutlined";
+import PersonAddOutlined from "@mui/icons-material/PersonAddOutlined";
 import { mobileNavigationElements } from "./NavigationElement";
 import { useDeviceContext } from "@/shared/context/DeviceContext";
+import { useAuthContext } from "@/features/auth/context";
 
 interface MobileDrawerComponentProps {
     isOpen: boolean;
@@ -13,8 +16,9 @@ export const MobileDrawerComponent: FC<MobileDrawerComponentProps> = ({ isOpen, 
     const navigate = useNavigate();
     const { pathname } = useLocation();
     const { pageSpecificNavigation } = useDeviceContext();
+    const { isAuthorized } = useAuthContext();
 
-    const isNavActive = (href: string) => pathname === href || pathname.startsWith(href + "/");
+    const isNavActive = (href: string) => pathname === href;
 
     return (
         <Drawer
@@ -24,7 +28,7 @@ export const MobileDrawerComponent: FC<MobileDrawerComponentProps> = ({ isOpen, 
             }}
         >
             <Box
-                sx={{ width: 250 }}
+                sx={{ width: "min(250px, 80vw)" }}
                 role="presentation"
                 onClick={() => {
                     setIsOpen(false);
@@ -64,6 +68,40 @@ export const MobileDrawerComponent: FC<MobileDrawerComponentProps> = ({ isOpen, 
                             </ListItem>
                         ))}
                     </List>
+                )}
+
+                {!isAuthorized && (
+                    <>
+                        <Divider />
+                        <List>
+                            <ListItem disablePadding>
+                                <ListItemButton
+                                    onClick={() => {
+                                        void navigate("/sign-in");
+                                    }}
+                                    selected={pathname === "/sign-in"}
+                                >
+                                    <ListItemIcon>
+                                        <LoginOutlined />
+                                    </ListItemIcon>
+                                    <ListItemText primary="Sign In" />
+                                </ListItemButton>
+                            </ListItem>
+                            <ListItem disablePadding>
+                                <ListItemButton
+                                    onClick={() => {
+                                        void navigate("/sign-up");
+                                    }}
+                                    selected={pathname === "/sign-up"}
+                                >
+                                    <ListItemIcon>
+                                        <PersonAddOutlined />
+                                    </ListItemIcon>
+                                    <ListItemText primary="Sign Up" />
+                                </ListItemButton>
+                            </ListItem>
+                        </List>
+                    </>
                 )}
             </Box>
         </Drawer>

--- a/edukate-frontend/src/shared/components/layout/topbar/NavigationElement.tsx
+++ b/edukate-frontend/src/shared/components/layout/topbar/NavigationElement.tsx
@@ -15,8 +15,8 @@ const homeNavigationElement: NavigationElement = {
 
 export const desktopNavigationElements: NavigationElement[] = [
     { text: "Problems", href: "/problems" },
-    { text: "Problem Sets", href: "/problem-sets" },
     { text: "Submissions", href: "/submissions" },
+    { text: "Problem Sets", href: "/problem-sets" },
 ];
 
 export const mobileNavigationElements: NavigationElement[] = [homeNavigationElement, ...desktopNavigationElements];

--- a/edukate-frontend/src/shared/components/pwa/InstallPrompt.test.tsx
+++ b/edukate-frontend/src/shared/components/pwa/InstallPrompt.test.tsx
@@ -1,0 +1,55 @@
+import userEvent from "@testing-library/user-event";
+import { render as rtlRender, screen, act, waitFor } from "@testing-library/react";
+import { FC, ReactNode } from "react";
+import { PwaProvider } from "@/shared/context/PwaContext";
+import { InstallPrompt } from "./InstallPrompt";
+
+const wrapper: FC<{ children: ReactNode }> = ({ children }) => <PwaProvider>{children}</PwaProvider>;
+
+function renderInstallPrompt() {
+    return rtlRender(<InstallPrompt />, { wrapper });
+}
+
+describe("InstallPrompt", () => {
+    it("is not visible when no beforeinstallprompt has fired", () => {
+        renderInstallPrompt();
+        expect(screen.queryByText(/install edukate/i)).not.toBeInTheDocument();
+    });
+
+    it("is visible after beforeinstallprompt fires", () => {
+        renderInstallPrompt();
+
+        act(() => {
+            window.dispatchEvent(new Event("beforeinstallprompt", { cancelable: true }));
+        });
+
+        expect(screen.getByText(/install edukate/i)).toBeInTheDocument();
+    });
+
+    it("has an Install action button", () => {
+        renderInstallPrompt();
+
+        act(() => {
+            window.dispatchEvent(new Event("beforeinstallprompt", { cancelable: true }));
+        });
+
+        expect(screen.getByRole("button", { name: /install/i })).toBeInTheDocument();
+    });
+
+    it("disappears when dismissed via the close button", async () => {
+        renderInstallPrompt();
+
+        act(() => {
+            window.dispatchEvent(new Event("beforeinstallprompt", { cancelable: true }));
+        });
+        expect(screen.getByText(/install edukate/i)).toBeInTheDocument();
+
+        const closeButton = screen.getByTestId("CloseIcon").closest("button");
+        expect(closeButton).not.toBeNull();
+        await userEvent.click(closeButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.queryByText(/install edukate/i)).not.toBeInTheDocument();
+        });
+    });
+});

--- a/edukate-frontend/src/shared/components/pwa/InstallPrompt.tsx
+++ b/edukate-frontend/src/shared/components/pwa/InstallPrompt.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { Button, IconButton, Snackbar } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { usePwaContext } from "@/shared/context/PwaContext";
+
+export function InstallPrompt() {
+    const { canInstall, promptInstall } = usePwaContext();
+    const [dismissed, setDismissed] = useState(false);
+
+    return (
+        <Snackbar
+            open={canInstall && !dismissed}
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            message="Install Edukate for a better experience"
+            action={
+                <>
+                    <Button color="secondary" size="small" onClick={promptInstall}>
+                        Install
+                    </Button>
+                    <IconButton
+                        size="small"
+                        color="inherit"
+                        onClick={() => {
+                            setDismissed(true);
+                        }}
+                    >
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                </>
+            }
+        />
+    );
+}

--- a/edukate-frontend/src/shared/components/pwa/OfflineBanner.test.tsx
+++ b/edukate-frontend/src/shared/components/pwa/OfflineBanner.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, act } from "@/test/render";
+import { OfflineBanner } from "./OfflineBanner";
+
+describe("OfflineBanner", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("shows the warning when offline", () => {
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+        render(<OfflineBanner />);
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+        expect(screen.getByText(/offline/i)).toBeInTheDocument();
+    });
+
+    it("displays the banner after going offline", () => {
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+        render(<OfflineBanner />);
+
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+        act(() => {
+            window.dispatchEvent(new Event("offline"));
+        });
+
+        expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+
+    it("has severity warning", () => {
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+        render(<OfflineBanner />);
+        const alert = screen.getByRole("alert");
+        expect(alert).toHaveClass("MuiAlert-standardWarning");
+    });
+});

--- a/edukate-frontend/src/shared/components/pwa/OfflineBanner.tsx
+++ b/edukate-frontend/src/shared/components/pwa/OfflineBanner.tsx
@@ -1,0 +1,14 @@
+import { Alert, Collapse } from "@mui/material";
+import { useOnlineStatus } from "@/shared/hooks/useOnlineStatus";
+
+export function OfflineBanner() {
+    const isOnline = useOnlineStatus();
+
+    return (
+        <Collapse in={!isOnline}>
+            <Alert severity="warning" sx={{ borderRadius: 0 }}>
+                You are offline. Some features may be unavailable.
+            </Alert>
+        </Collapse>
+    );
+}

--- a/edukate-frontend/src/shared/components/pwa/UpdatePrompt.test.tsx
+++ b/edukate-frontend/src/shared/components/pwa/UpdatePrompt.test.tsx
@@ -1,0 +1,55 @@
+import userEvent from "@testing-library/user-event";
+import { render as rtlRender, screen, act, waitFor } from "@testing-library/react";
+import { FC, ReactNode } from "react";
+import { PwaProvider } from "@/shared/context/PwaContext";
+import { UpdatePrompt } from "./UpdatePrompt";
+
+const wrapper: FC<{ children: ReactNode }> = ({ children }) => <PwaProvider>{children}</PwaProvider>;
+
+function renderUpdatePrompt() {
+    return rtlRender(<UpdatePrompt />, { wrapper });
+}
+
+describe("UpdatePrompt", () => {
+    it("is not visible when no update is available", () => {
+        renderUpdatePrompt();
+        expect(screen.queryByText(/new version/i)).not.toBeInTheDocument();
+    });
+
+    it("is visible after sw-update-available fires", () => {
+        renderUpdatePrompt();
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent("sw-update-available"));
+        });
+
+        expect(screen.getByText(/new version/i)).toBeInTheDocument();
+    });
+
+    it("has an Update action button", () => {
+        renderUpdatePrompt();
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent("sw-update-available"));
+        });
+
+        expect(screen.getByRole("button", { name: /update/i })).toBeInTheDocument();
+    });
+
+    it("disappears when dismissed via the close button", async () => {
+        renderUpdatePrompt();
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent("sw-update-available"));
+        });
+        expect(screen.getByText(/new version/i)).toBeInTheDocument();
+
+        const closeButton = screen.getByTestId("CloseIcon").closest("button");
+        expect(closeButton).not.toBeNull();
+        await userEvent.click(closeButton as HTMLElement);
+
+        await waitFor(() => {
+            expect(screen.queryByText(/new version/i)).not.toBeInTheDocument();
+        });
+    });
+});

--- a/edukate-frontend/src/shared/components/pwa/UpdatePrompt.tsx
+++ b/edukate-frontend/src/shared/components/pwa/UpdatePrompt.tsx
@@ -1,0 +1,33 @@
+import { useState } from "react";
+import { Button, IconButton, Snackbar } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import { usePwaContext } from "@/shared/context/PwaContext";
+
+export function UpdatePrompt() {
+    const { updateAvailable, applyUpdate } = usePwaContext();
+    const [dismissed, setDismissed] = useState(false);
+
+    return (
+        <Snackbar
+            open={updateAvailable && !dismissed}
+            anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+            message="A new version of Edukate is available"
+            action={
+                <>
+                    <Button color="secondary" size="small" onClick={applyUpdate}>
+                        Update
+                    </Button>
+                    <IconButton
+                        size="small"
+                        color="inherit"
+                        onClick={() => {
+                            setDismissed(true);
+                        }}
+                    >
+                        <CloseIcon fontSize="small" />
+                    </IconButton>
+                </>
+            }
+        />
+    );
+}

--- a/edukate-frontend/src/shared/context/PwaContext.test.tsx
+++ b/edukate-frontend/src/shared/context/PwaContext.test.tsx
@@ -1,0 +1,62 @@
+import { renderHook, act } from "@testing-library/react";
+import { FC, ReactNode } from "react";
+import { PwaProvider, usePwaContext } from "./PwaContext";
+
+const wrapper: FC<{ children: ReactNode }> = ({ children }) => <PwaProvider>{children}</PwaProvider>;
+
+describe("PwaContext", () => {
+    it("canInstall is false by default", () => {
+        const { result } = renderHook(() => usePwaContext(), { wrapper });
+        expect(result.current.canInstall).toBe(false);
+    });
+
+    it("updateAvailable is false by default", () => {
+        const { result } = renderHook(() => usePwaContext(), { wrapper });
+        expect(result.current.updateAvailable).toBe(false);
+    });
+
+    it("sets canInstall to true when beforeinstallprompt fires", () => {
+        const { result } = renderHook(() => usePwaContext(), { wrapper });
+
+        act(() => {
+            const event = new Event("beforeinstallprompt", { cancelable: true });
+            window.dispatchEvent(event);
+        });
+
+        expect(result.current.canInstall).toBe(true);
+    });
+
+    it("prevents default on beforeinstallprompt to suppress browser mini-infobar", () => {
+        renderHook(() => usePwaContext(), { wrapper });
+
+        let defaultPrevented = false;
+        act(() => {
+            const event = new Event("beforeinstallprompt", { cancelable: true });
+            window.dispatchEvent(event);
+            defaultPrevented = event.defaultPrevented;
+        });
+
+        expect(defaultPrevented).toBe(true);
+    });
+
+    it("sets updateAvailable to true when sw-update-available fires", () => {
+        const { result } = renderHook(() => usePwaContext(), { wrapper });
+
+        act(() => {
+            window.dispatchEvent(new CustomEvent("sw-update-available"));
+        });
+
+        expect(result.current.updateAvailable).toBe(true);
+    });
+
+    it("cleans up event listeners on unmount", () => {
+        const removeSpy = vi.spyOn(window, "removeEventListener");
+        const { unmount } = renderHook(() => usePwaContext(), { wrapper });
+
+        unmount();
+
+        const removedEvents = removeSpy.mock.calls.map(([event]) => event);
+        expect(removedEvents).toContain("beforeinstallprompt");
+        expect(removedEvents).toContain("sw-update-available");
+    });
+});

--- a/edukate-frontend/src/shared/context/PwaContext.tsx
+++ b/edukate-frontend/src/shared/context/PwaContext.tsx
@@ -1,0 +1,66 @@
+import { createContext, FC, ReactNode, useCallback, useContext, useEffect, useState } from "react";
+
+interface BeforeInstallPromptEvent extends Event {
+    prompt(): Promise<{ outcome: "accepted" | "dismissed" }>;
+}
+
+type PwaContextType = {
+    canInstall: boolean;
+    promptInstall: () => void;
+    updateAvailable: boolean;
+    applyUpdate: () => void;
+};
+
+const PwaContext = createContext<PwaContextType>({
+    canInstall: false,
+    promptInstall: () => {},
+    updateAvailable: false,
+    applyUpdate: () => {},
+});
+
+export const PwaProvider: FC<{ children: ReactNode }> = ({ children }) => {
+    const [installEvent, setInstallEvent] = useState<BeforeInstallPromptEvent | null>(null);
+    const [updateAvailable, setUpdateAvailable] = useState(false);
+
+    useEffect(() => {
+        const handler = (e: Event) => {
+            e.preventDefault();
+            setInstallEvent(e as BeforeInstallPromptEvent);
+        };
+        window.addEventListener("beforeinstallprompt", handler);
+        return () => {
+            window.removeEventListener("beforeinstallprompt", handler);
+        };
+    }, []);
+
+    useEffect(() => {
+        const handler = () => {
+            setUpdateAvailable(true);
+        };
+        window.addEventListener("sw-update-available", handler);
+        return () => {
+            window.removeEventListener("sw-update-available", handler);
+        };
+    }, []);
+
+    const promptInstall = useCallback(() => {
+        if (installEvent) {
+            void installEvent.prompt().then(({ outcome }) => {
+                if (outcome === "accepted") setInstallEvent(null);
+            });
+        }
+    }, [installEvent]);
+
+    const applyUpdate = useCallback(() => {
+        const updateSW = (window as unknown as { __updateSW?: (reload?: boolean) => Promise<void> }).__updateSW;
+        if (updateSW) void updateSW(true);
+    }, []);
+
+    return (
+        <PwaContext.Provider value={{ canInstall: installEvent !== null, promptInstall, updateAvailable, applyUpdate }}>
+            {children}
+        </PwaContext.Provider>
+    );
+};
+
+export const usePwaContext = () => useContext(PwaContext);

--- a/edukate-frontend/src/shared/context/themes.ts
+++ b/edukate-frontend/src/shared/context/themes.ts
@@ -54,6 +54,7 @@ const darkTheme = createTheme({
             default: "#36393e",
             paper: "#424549",
         },
+        divider: "rgba(255, 255, 255, 0.3)",
     },
     typography,
     components,

--- a/edukate-frontend/src/shared/hooks/useOnlineStatus.test.ts
+++ b/edukate-frontend/src/shared/hooks/useOnlineStatus.test.ts
@@ -1,0 +1,55 @@
+import { renderHook, act } from "@testing-library/react";
+import { useOnlineStatus } from "./useOnlineStatus";
+
+describe("useOnlineStatus", () => {
+    it("returns true when the browser is online", () => {
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+        const { result } = renderHook(() => useOnlineStatus());
+        expect(result.current).toBe(true);
+    });
+
+    it("returns false when the browser is offline", () => {
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+        const { result } = renderHook(() => useOnlineStatus());
+        expect(result.current).toBe(false);
+    });
+
+    it("updates when the browser goes offline", () => {
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+        const { result } = renderHook(() => useOnlineStatus());
+        expect(result.current).toBe(true);
+
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+        act(() => {
+            window.dispatchEvent(new Event("offline"));
+        });
+        expect(result.current).toBe(false);
+    });
+
+    it("updates when the browser comes back online", () => {
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+        const { result } = renderHook(() => useOnlineStatus());
+        expect(result.current).toBe(false);
+
+        vi.spyOn(navigator, "onLine", "get").mockReturnValue(true);
+        act(() => {
+            window.dispatchEvent(new Event("online"));
+        });
+        expect(result.current).toBe(true);
+    });
+
+    it("cleans up event listeners on unmount", () => {
+        const addSpy = vi.spyOn(window, "addEventListener");
+        const removeSpy = vi.spyOn(window, "removeEventListener");
+
+        const { unmount } = renderHook(() => useOnlineStatus());
+
+        expect(addSpy).toHaveBeenCalledWith("online", expect.any(Function));
+        expect(addSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+
+        unmount();
+
+        expect(removeSpy).toHaveBeenCalledWith("online", expect.any(Function));
+        expect(removeSpy).toHaveBeenCalledWith("offline", expect.any(Function));
+    });
+});

--- a/edukate-frontend/src/shared/hooks/useOnlineStatus.ts
+++ b/edukate-frontend/src/shared/hooks/useOnlineStatus.ts
@@ -1,0 +1,18 @@
+import { useSyncExternalStore } from "react";
+
+function subscribe(callback: () => void) {
+    window.addEventListener("online", callback);
+    window.addEventListener("offline", callback);
+    return () => {
+        window.removeEventListener("online", callback);
+        window.removeEventListener("offline", callback);
+    };
+}
+
+function getSnapshot() {
+    return navigator.onLine;
+}
+
+export function useOnlineStatus(): boolean {
+    return useSyncExternalStore(subscribe, getSnapshot);
+}

--- a/edukate-frontend/src/vite-env.d.ts
+++ b/edukate-frontend/src/vite-env.d.ts
@@ -1,3 +1,4 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/client" />
 
 declare const __BUILD_TIME__: string;

--- a/edukate-frontend/vite.config.ts
+++ b/edukate-frontend/vite.config.ts
@@ -1,11 +1,37 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
+import { VitePWA } from "vite-plugin-pwa";
 import path from "path";
 import { visualizer } from "rollup-plugin-visualizer";
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
-    plugins: [react(), mode === "analyze" && visualizer({ open: true, filename: "dist/stats.html", gzipSize: true })],
+    plugins: [
+        react(),
+        VitePWA({
+            registerType: "prompt",
+            manifest: false,
+            devOptions: { enabled: false },
+            workbox: {
+                globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+                navigateFallback: "/index.html",
+                navigateFallbackDenylist: [/^\/api\//],
+                runtimeCaching: [
+                    {
+                        urlPattern: /^https?:\/\/.*\/api\//,
+                        handler: "NetworkFirst",
+                        options: {
+                            cacheName: "api-cache",
+                            expiration: { maxEntries: 100, maxAgeSeconds: 300 },
+                            cacheableResponse: { statuses: [0, 200] },
+                            networkTimeoutSeconds: 5,
+                        },
+                    },
+                ],
+            },
+        }),
+        mode === "analyze" && visualizer({ open: true, filename: "dist/stats.html", gzipSize: true }),
+    ],
     define: {
         __BUILD_TIME__: JSON.stringify(new Date().toISOString()),
     },

--- a/spec/openapi-edukate-backend.yaml
+++ b/spec/openapi-edukate-backend.yaml
@@ -1704,9 +1704,13 @@ components:
           - SOLVING
           - FAILED
           - NOT_SOLVED
+        createdAt:
+          type: string
+          format: date-time
       required:
       - bookSlug
       - code
+      - createdAt
       - isHard
       - key
       - status


### PR DESCRIPTION
## What's done:

### PWA Infrastructure
  - Service worker generation via vite-plugin-pwa with Workbox precaching and NetworkFirst API caching
  - Web manifest enhanced with start_url, scope, id, maskable icon for full installability
  - iOS/Android meta tags (theme-color, apple-mobile-web-app-capable, status bar style)
  - PwaContext capturing beforeinstallprompt and SW update events
  - Dismissible install/update Snackbar prompts (bottom-right, reset on page reload)
  - OfflineBanner component using useOnlineStatus hook (useSyncExternalStore)
  - nginx.conf updated with no-cache rules for sw.js and site.webmanifest

### Responsive Tables
  - Problem table: 3-tier column visibility (xs: status/book/name, sm: +created, md+: +tags)
  - Submission table: split problemKey into separate Book and Problem columns, show User on all sizes
  - Clickable book slug and username text with hover underline (replaced chips)
  - ClearableTextField shared component with stable-size clear icon
  - Separate Book + Problem code filter inputs in both toolbars
  - Unified status icons (CheckCircleOutline, HourglassEmpty, CancelOutlined) across tables

### Problem Table Toolbar
  - Responsive layout: xs (3 rows) → md (2 rows) → lg+ (inputs row + checkboxes row)
  - Random Problem Button as FAB on mobile, absolute-positioned on desktop
  - Compact checkboxes aligned with input fields

### Other UI Improvements
  - Navigation reordered: Problems, Submissions, Problem Sets
  - Nav links highlight only on exact page match
  - Lightbox replaces FilePreviewDialog (zoom, swipe-to-close, backdrop click)
  - Problem set sidebar: tighter icon-text gap on md screens
  - FileUpload width matches AnswerAccordion and SubmissionsCard (80% on sm+)
  - Uniform 120px top padding across all screen sizes

### Backend
  - created_at column added to problems table (V1 migration)
  - Problem entity, ProblemMetadata DTO, and ProblemMapper updated
  - Dev data seeded with staggered timestamps (June 2025 – April 2026)

### Tests
  - useOnlineStatus, ClearableTextField, BookChip, PwaContext, OfflineBanner, InstallPrompt, UpdatePrompt (32 new frontend tests)
  - ProblemMapperTest: createdAt propagation, bookSlug resolution, missing book fallback (3 new backend tests)
  - Existing tests updated for split Book/Problem columns