### PR TITLE
Add endpoint to retrieve code-to-ID map for problems

### DIFF
--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/internal/ProblemInternalController.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/controllers/internal/ProblemInternalController.kt
@@ -5,10 +5,12 @@ import io.github.sanyavertolet.edukate.backend.services.ProblemService
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.annotations.security.SecurityRequirements
 import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
@@ -22,6 +24,9 @@ class ProblemInternalController(private val problemService: ProblemService) {
 
     @PostMapping("/batch")
     fun postProblemBatch(@RequestBody problems: Flux<Problem>): Mono<Long> = problemService.updateProblemBatch(problems)
+
+    @GetMapping("/code-to-id")
+    fun getCodeToIdMap(@RequestParam bookId: Long): Mono<Map<String, Long>> = problemService.findCodeToIdMap(bookId)
 
     @DeleteMapping("/{id}") fun deleteProblem(@PathVariable id: Long): Mono<Void> = problemService.deleteProblemById(id)
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/repositories/ProblemRepository.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/repositories/ProblemRepository.kt
@@ -17,6 +17,8 @@ interface ProblemRepository : ReactiveCrudRepository<Problem, Long>, ReactiveSor
 
     fun findByIdIn(ids: Collection<Long>): Flux<Problem>
 
+    fun findAllByBookId(bookId: Long): Flux<Problem>
+
     @Query("SELECT * FROM problems WHERE code LIKE :prefix || '%' ORDER BY string_to_array(code, '.')::int[] LIMIT :limit")
     fun findByCodeStartingWith(prefix: String, limit: Int): Flux<Problem>
 

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/ProblemService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/ProblemService.kt
@@ -91,6 +91,9 @@ class ProblemService(private val problemRepository: ProblemRepository, private v
     )
     fun deleteProblemById(id: Long): Mono<Void> = problemRepository.deleteById(id)
 
+    fun findCodeToIdMap(bookId: Long): Mono<Map<String, Long>> =
+        problemRepository.findAllByBookId(bookId).collectMap({ it.code }, { requireNotNull(it.id) })
+
     fun getProblemCodesByPrefix(prefix: String, limit: Int): Flux<String> =
         problemRepository.findByCodeStartingWith(prefix, limit).map { it.code }
 

--- a/edukate-chart/values.yaml
+++ b/edukate-chart/values.yaml
@@ -85,7 +85,7 @@ mongodb:
 
 postgresql:
   enabled: true
-  secretName: postgresql-secrets
+  secretName: postgres-secrets
   secretKey:
     backendR2dbc: backendR2dbcUrl
     backendFlyway: backendFlywayUrl


### PR DESCRIPTION
### What's done:
 * Introduced a new `findCodeToIdMap` method in `ProblemService` to fetch a map of problem codes to their IDs for a specific book.
 * Added a new `GET /code-to-id` endpoint in `ProblemInternalController` to utilize this service method.
 * Extended `ProblemRepository` with a `findAllByBookId` method to support the query.
 * Updated `values.yaml` to align `postgresql.secretName` with the correct name (`postgres-secrets`).