### PR TITLE
Add Problem Picker & Book Ingestion Tests

### DIFF
--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/repositories/AnswerLocalizationRepository.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/repositories/AnswerLocalizationRepository.kt
@@ -2,6 +2,8 @@ package io.github.sanyavertolet.edukate.backend.repositories
 
 import io.github.sanyavertolet.edukate.backend.entities.AnswerLocalization
 import io.github.sanyavertolet.edukate.common.ContentLanguage
+import org.springframework.data.r2dbc.repository.Modifying
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import org.springframework.stereotype.Repository
 import reactor.core.publisher.Mono
@@ -11,4 +13,16 @@ interface AnswerLocalizationRepository : ReactiveCrudRepository<AnswerLocalizati
     fun findByAnswerIdAndLanguage(answerId: Long, language: ContentLanguage): Mono<AnswerLocalization>
 
     fun findFirstByAnswerId(answerId: Long): Mono<AnswerLocalization>
+
+    @Modifying
+    @Query(
+        """
+        INSERT INTO answer_localizations (answer_id, language, text, notes)
+        VALUES (:answerId, :language, :text, :notes)
+        ON CONFLICT (answer_id, language) DO UPDATE SET
+            text = EXCLUDED.text,
+            notes = EXCLUDED.notes
+    """
+    )
+    fun upsert(answerId: Long, language: ContentLanguage, text: String, notes: String?): Mono<Int>
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/repositories/ProblemLocalizationRepository.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/repositories/ProblemLocalizationRepository.kt
@@ -1,7 +1,10 @@
 package io.github.sanyavertolet.edukate.backend.repositories
 
 import io.github.sanyavertolet.edukate.backend.entities.ProblemLocalization
+import io.github.sanyavertolet.edukate.backend.entities.Subproblem
 import io.github.sanyavertolet.edukate.common.ContentLanguage
+import org.springframework.data.r2dbc.repository.Modifying
+import org.springframework.data.r2dbc.repository.Query
 import org.springframework.data.repository.reactive.ReactiveCrudRepository
 import org.springframework.stereotype.Repository
 import reactor.core.publisher.Mono
@@ -11,4 +14,23 @@ interface ProblemLocalizationRepository : ReactiveCrudRepository<ProblemLocaliza
     fun findByProblemIdAndLanguage(problemId: Long, language: ContentLanguage): Mono<ProblemLocalization>
 
     fun findFirstByProblemId(problemId: Long): Mono<ProblemLocalization>
+
+    @Modifying
+    @Query(
+        """
+        INSERT INTO problem_localizations (problem_id, language, text, tags, subproblems)
+        VALUES (:problemId, :language, :text, :tags, :subproblems)
+        ON CONFLICT (problem_id, language) DO UPDATE SET
+            text = EXCLUDED.text,
+            tags = EXCLUDED.tags,
+            subproblems = EXCLUDED.subproblems
+    """
+    )
+    fun upsert(
+        problemId: Long,
+        language: ContentLanguage,
+        text: String,
+        tags: List<String>,
+        subproblems: List<Subproblem>,
+    ): Mono<Int>
 }

--- a/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/BookIngestionService.kt
+++ b/edukate-backend/src/main/kotlin/io/github/sanyavertolet/edukate/backend/services/BookIngestionService.kt
@@ -1,13 +1,12 @@
 package io.github.sanyavertolet.edukate.backend.services
 
+import io.github.sanyavertolet.edukate.backend.dtos.ingestion.AnswerIngestionEntry
 import io.github.sanyavertolet.edukate.backend.dtos.ingestion.BookIngestionRequest
 import io.github.sanyavertolet.edukate.backend.dtos.ingestion.BookIngestionResponse
 import io.github.sanyavertolet.edukate.backend.dtos.ingestion.ProblemIngestionEntry
 import io.github.sanyavertolet.edukate.backend.entities.Answer
-import io.github.sanyavertolet.edukate.backend.entities.AnswerLocalization
 import io.github.sanyavertolet.edukate.backend.entities.Book
 import io.github.sanyavertolet.edukate.backend.entities.Problem
-import io.github.sanyavertolet.edukate.backend.entities.ProblemLocalization
 import io.github.sanyavertolet.edukate.backend.repositories.AnswerLocalizationRepository
 import io.github.sanyavertolet.edukate.backend.repositories.AnswerRepository
 import io.github.sanyavertolet.edukate.backend.repositories.ProblemLocalizationRepository
@@ -47,7 +46,7 @@ class BookIngestionService(
                             .then(Mono.just(Unit))
                     )
                 }
-                .thenReturn(
+                .map {
                     BookIngestionResponse(
                         bookSlug = slug,
                         problemCount = problemCount,
@@ -55,7 +54,7 @@ class BookIngestionService(
                         problemLocalizationCount = problemLocCount,
                         answerLocalizationCount = answerLocCount,
                     )
-                )
+                }
         }
 
     private fun upsertBook(request: BookIngestionRequest): Mono<Book> {
@@ -114,59 +113,22 @@ class BookIngestionService(
     private fun upsertProblemLocalizations(problemId: Long, entry: ProblemIngestionEntry): Mono<Int> =
         entry.localizations.entries.fold(Mono.just(0)) { chain, (language, data) ->
             chain.flatMap { count ->
-                problemLocalizationRepository
-                    .findByProblemIdAndLanguage(problemId, language)
-                    .flatMap { existing ->
-                        problemLocalizationRepository.save(
-                            existing.copy(text = data.text, tags = data.tags, subproblems = data.subproblems)
-                        )
-                    }
-                    .switchIfEmpty(
-                        problemLocalizationRepository.save(
-                            ProblemLocalization(
-                                problemId = problemId,
-                                language = language,
-                                text = data.text,
-                                tags = data.tags,
-                                subproblems = data.subproblems,
-                            )
-                        )
-                    )
-                    .map { count + 1 }
+                problemLocalizationRepository.upsert(problemId, language, data.text, data.tags, data.subproblems).map {
+                    count + 1
+                }
             }
         }
 
-    private fun upsertAnswer(
-        problemId: Long,
-        answerEntry: io.github.sanyavertolet.edukate.backend.dtos.ingestion.AnswerIngestionEntry,
-    ): Mono<Answer> =
+    private fun upsertAnswer(problemId: Long, answerEntry: AnswerIngestionEntry): Mono<Answer> =
         answerRepository
             .findByProblemId(problemId)
             .flatMap { existing -> answerRepository.save(existing.copy(images = answerEntry.images)) }
             .switchIfEmpty(answerRepository.save(Answer(problemId = problemId, images = answerEntry.images)))
 
-    private fun upsertAnswerLocalizations(
-        answerId: Long,
-        answerEntry: io.github.sanyavertolet.edukate.backend.dtos.ingestion.AnswerIngestionEntry,
-    ): Mono<Int> =
+    private fun upsertAnswerLocalizations(answerId: Long, answerEntry: AnswerIngestionEntry): Mono<Int> =
         answerEntry.localizations.entries.fold(Mono.just(0)) { chain, (language, data) ->
             chain.flatMap { count ->
-                answerLocalizationRepository
-                    .findByAnswerIdAndLanguage(answerId, language)
-                    .flatMap { existing ->
-                        answerLocalizationRepository.save(existing.copy(text = data.text, notes = data.notes))
-                    }
-                    .switchIfEmpty(
-                        answerLocalizationRepository.save(
-                            AnswerLocalization(
-                                answerId = answerId,
-                                language = language,
-                                text = data.text,
-                                notes = data.notes,
-                            )
-                        )
-                    )
-                    .map { count + 1 }
+                answerLocalizationRepository.upsert(answerId, language, data.text, data.notes).map { count + 1 }
             }
         }
 }

--- a/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/BookIngestionServiceTest.kt
+++ b/edukate-backend/src/test/kotlin/io/github/sanyavertolet/edukate/backend/services/BookIngestionServiceTest.kt
@@ -1,0 +1,238 @@
+@file:Suppress("ReactiveStreamsUnusedPublisher")
+
+package io.github.sanyavertolet.edukate.backend.services
+
+import io.github.sanyavertolet.edukate.backend.BackendFixtures
+import io.github.sanyavertolet.edukate.backend.dtos.ingestion.AnswerIngestionEntry
+import io.github.sanyavertolet.edukate.backend.dtos.ingestion.AnswerLocalizationData
+import io.github.sanyavertolet.edukate.backend.dtos.ingestion.BookData
+import io.github.sanyavertolet.edukate.backend.dtos.ingestion.BookIngestionRequest
+import io.github.sanyavertolet.edukate.backend.dtos.ingestion.ProblemIngestionEntry
+import io.github.sanyavertolet.edukate.backend.dtos.ingestion.ProblemLocalizationData
+import io.github.sanyavertolet.edukate.backend.repositories.AnswerLocalizationRepository
+import io.github.sanyavertolet.edukate.backend.repositories.AnswerRepository
+import io.github.sanyavertolet.edukate.backend.repositories.ProblemLocalizationRepository
+import io.github.sanyavertolet.edukate.backend.repositories.ProblemRepository
+import io.github.sanyavertolet.edukate.common.ContentLanguage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
+
+class BookIngestionServiceTest {
+    private val bookService: BookService = mockk()
+    private val problemRepository: ProblemRepository = mockk()
+    private val answerRepository: AnswerRepository = mockk()
+    private val problemLocalizationRepository: ProblemLocalizationRepository = mockk()
+    private val answerLocalizationRepository: AnswerLocalizationRepository = mockk()
+    private lateinit var service: BookIngestionService
+
+    @BeforeEach
+    fun setUp() {
+        service =
+            BookIngestionService(
+                bookService,
+                problemRepository,
+                answerRepository,
+                problemLocalizationRepository,
+                answerLocalizationRepository,
+            )
+    }
+
+    private fun bookData(slug: String = "savchenko") =
+        BookData(
+            slug = slug,
+            subject = "physics",
+            title = "Savchenko",
+            citation = "Savchenko O.Ya., 1988",
+            description = null,
+        )
+
+    private fun problemEntry(
+        code: String = "1.1.1",
+        localizations: Map<ContentLanguage, ProblemLocalizationData> =
+            mapOf(ContentLanguage.RU to ProblemLocalizationData(text = "Тело массой m...")),
+        answer: AnswerIngestionEntry? = null,
+    ) = ProblemIngestionEntry(code = code, localizations = localizations, answer = answer)
+
+    private fun answerEntry(
+        localizations: Map<ContentLanguage, AnswerLocalizationData> =
+            mapOf(ContentLanguage.RU to AnswerLocalizationData(text = "v = 10 м/с"))
+    ) = AnswerIngestionEntry(localizations = localizations)
+
+    @Test
+    fun `ingest creates new book and problem when neither exists`() {
+        val book = BackendFixtures.book(id = 1L, slug = "savchenko")
+        val problem = BackendFixtures.problem(id = 1L, code = "1.1.1", key = "savchenko/1.1.1")
+
+        every { bookService.findBySlug("savchenko") } returns Mono.empty()
+        every { bookService.save(any()) } returns Mono.just(book)
+        every { problemRepository.findByKey("savchenko/1.1.1") } returns Mono.empty()
+        every { problemRepository.save(any()) } returns Mono.just(problem)
+        every { problemLocalizationRepository.upsert(1L, ContentLanguage.RU, any(), any(), any()) } returns Mono.just(1)
+
+        val request = BookIngestionRequest(bookData(), listOf(problemEntry()))
+
+        StepVerifier.create(service.ingest(request))
+            .assertNext { response ->
+                assertThat(response.bookSlug).isEqualTo("savchenko")
+                assertThat(response.problemCount).isEqualTo(1)
+                assertThat(response.problemLocalizationCount).isEqualTo(1)
+                assertThat(response.answerCount).isEqualTo(0)
+                assertThat(response.answerLocalizationCount).isEqualTo(0)
+            }
+            .verifyComplete()
+
+        verify(exactly = 1) { bookService.save(any()) }
+        verify(exactly = 1) { problemRepository.save(any()) }
+        verify(exactly = 1) { problemLocalizationRepository.upsert(1L, ContentLanguage.RU, any(), any(), any()) }
+    }
+
+    @Test
+    fun `ingest updates existing book and problem`() {
+        val existingBook = BackendFixtures.book(id = 5L, slug = "savchenko")
+        val existingProblem = BackendFixtures.problem(id = 2L, key = "savchenko/1.1.1")
+
+        every { bookService.findBySlug("savchenko") } returns Mono.just(existingBook)
+        every { bookService.save(any()) } returns Mono.just(existingBook)
+        every { problemRepository.findByKey("savchenko/1.1.1") } returns Mono.just(existingProblem)
+        every { problemRepository.save(any()) } returns Mono.just(existingProblem)
+        every { problemLocalizationRepository.upsert(2L, ContentLanguage.RU, any(), any(), any()) } returns Mono.just(1)
+
+        StepVerifier.create(service.ingest(BookIngestionRequest(bookData(), listOf(problemEntry()))))
+            .assertNext { response ->
+                assertThat(response.problemCount).isEqualTo(1)
+                assertThat(response.problemLocalizationCount).isEqualTo(1)
+            }
+            .verifyComplete()
+
+        verify(exactly = 1) { bookService.save(match { it.id == 5L }) }
+        verify(exactly = 1) { problemRepository.save(match { it.id == 2L }) }
+    }
+
+    @Test
+    fun `ingest with answer creates answer and answer localization`() {
+        val book = BackendFixtures.book(id = 1L, slug = "savchenko")
+        val problem = BackendFixtures.problem(id = 1L, key = "savchenko/1.1.1")
+        val answer = BackendFixtures.answer(id = 10L, problemId = 1L)
+
+        every { bookService.findBySlug("savchenko") } returns Mono.empty()
+        every { bookService.save(any()) } returns Mono.just(book)
+        every { problemRepository.findByKey("savchenko/1.1.1") } returns Mono.empty()
+        every { problemRepository.save(any()) } returns Mono.just(problem)
+        every { problemLocalizationRepository.upsert(1L, ContentLanguage.RU, any(), any(), any()) } returns Mono.just(1)
+        every { answerRepository.findByProblemId(1L) } returns Mono.empty()
+        every { answerRepository.save(any()) } returns Mono.just(answer)
+        every { answerLocalizationRepository.upsert(10L, ContentLanguage.RU, "v = 10 м/с", null) } returns Mono.just(1)
+
+        StepVerifier.create(service.ingest(BookIngestionRequest(bookData(), listOf(problemEntry(answer = answerEntry())))))
+            .assertNext { response ->
+                assertThat(response.answerCount).isEqualTo(1)
+                assertThat(response.answerLocalizationCount).isEqualTo(1)
+            }
+            .verifyComplete()
+
+        verify(exactly = 1) { answerRepository.save(any()) }
+        verify(exactly = 1) { answerLocalizationRepository.upsert(10L, ContentLanguage.RU, "v = 10 м/с", null) }
+    }
+
+    @Test
+    fun `ingest without answer skips answer repositories`() {
+        val book = BackendFixtures.book(id = 1L, slug = "savchenko")
+        val problem = BackendFixtures.problem(id = 1L, key = "savchenko/1.1.1")
+
+        every { bookService.findBySlug("savchenko") } returns Mono.empty()
+        every { bookService.save(any()) } returns Mono.just(book)
+        every { problemRepository.findByKey("savchenko/1.1.1") } returns Mono.empty()
+        every { problemRepository.save(any()) } returns Mono.just(problem)
+        every { problemLocalizationRepository.upsert(1L, ContentLanguage.RU, any(), any(), any()) } returns Mono.just(1)
+
+        StepVerifier.create(service.ingest(BookIngestionRequest(bookData(), listOf(problemEntry(answer = null)))))
+            .assertNext { response -> assertThat(response.answerCount).isEqualTo(0) }
+            .verifyComplete()
+
+        verify(exactly = 0) { answerRepository.save(any()) }
+        verify(exactly = 0) { answerLocalizationRepository.upsert(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `ingest with two localizations upserts both`() {
+        val book = BackendFixtures.book(id = 1L, slug = "savchenko")
+        val problem = BackendFixtures.problem(id = 1L, key = "savchenko/1.1.1")
+
+        every { bookService.findBySlug("savchenko") } returns Mono.empty()
+        every { bookService.save(any()) } returns Mono.just(book)
+        every { problemRepository.findByKey("savchenko/1.1.1") } returns Mono.empty()
+        every { problemRepository.save(any()) } returns Mono.just(problem)
+        every { problemLocalizationRepository.upsert(1L, any(), any(), any(), any()) } returns Mono.just(1)
+
+        val localizations =
+            mapOf(
+                ContentLanguage.RU to ProblemLocalizationData("Тело массой m..."),
+                ContentLanguage.EN to ProblemLocalizationData("A body of mass m..."),
+            )
+
+        StepVerifier.create(
+                service.ingest(BookIngestionRequest(bookData(), listOf(problemEntry(localizations = localizations))))
+            )
+            .assertNext { response -> assertThat(response.problemLocalizationCount).isEqualTo(2) }
+            .verifyComplete()
+
+        verify(exactly = 1) { problemLocalizationRepository.upsert(1L, ContentLanguage.RU, any(), any(), any()) }
+        verify(exactly = 1) { problemLocalizationRepository.upsert(1L, ContentLanguage.EN, any(), any(), any()) }
+    }
+
+    @Test
+    fun `ingest existing localizations completes without error`() {
+        val book = BackendFixtures.book(id = 1L, slug = "savchenko")
+        val problem = BackendFixtures.problem(id = 1L, key = "savchenko/1.1.1")
+
+        every { bookService.findBySlug("savchenko") } returns Mono.just(book)
+        every { bookService.save(any()) } returns Mono.just(book)
+        every { problemRepository.findByKey("savchenko/1.1.1") } returns Mono.just(problem)
+        every { problemRepository.save(any()) } returns Mono.just(problem)
+        every { problemLocalizationRepository.upsert(1L, ContentLanguage.RU, any(), any(), any()) } returns Mono.just(1)
+
+        StepVerifier.create(service.ingest(BookIngestionRequest(bookData(), listOf(problemEntry()))))
+            .assertNext {}
+            .verifyComplete()
+    }
+
+    @Test
+    fun `ingest multiple problems returns correct aggregate counts`() {
+        val book = BackendFixtures.book(id = 1L, slug = "savchenko")
+        val problem1 = BackendFixtures.problem(id = 1L, code = "1.1.1", key = "savchenko/1.1.1")
+        val problem2 = BackendFixtures.problem(id = 2L, code = "1.1.2", key = "savchenko/1.1.2")
+        val answer2 = BackendFixtures.answer(id = 20L, problemId = 2L)
+
+        every { bookService.findBySlug("savchenko") } returns Mono.empty()
+        every { bookService.save(any()) } returns Mono.just(book)
+        every { problemRepository.findByKey("savchenko/1.1.1") } returns Mono.empty()
+        every { problemRepository.findByKey("savchenko/1.1.2") } returns Mono.empty()
+        every { problemRepository.save(match { it.code == "1.1.1" }) } returns Mono.just(problem1)
+        every { problemRepository.save(match { it.code == "1.1.2" }) } returns Mono.just(problem2)
+        every { problemLocalizationRepository.upsert(any(), any(), any(), any(), any()) } returns Mono.just(1)
+        every { answerRepository.findByProblemId(2L) } returns Mono.empty()
+        every { answerRepository.save(any()) } returns Mono.just(answer2)
+        every { answerLocalizationRepository.upsert(20L, ContentLanguage.RU, any(), any()) } returns Mono.just(1)
+
+        val request =
+            BookIngestionRequest(
+                bookData(),
+                listOf(problemEntry(code = "1.1.1"), problemEntry(code = "1.1.2", answer = answerEntry())),
+            )
+
+        StepVerifier.create(service.ingest(request))
+            .assertNext { response ->
+                assertThat(response.problemCount).isEqualTo(2)
+                assertThat(response.problemLocalizationCount).isEqualTo(2)
+                assertThat(response.answerCount).isEqualTo(1)
+                assertThat(response.answerLocalizationCount).isEqualTo(1)
+            }
+            .verifyComplete()
+    }
+}

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemPicker.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemPicker.tsx
@@ -1,0 +1,136 @@
+import {
+    Checkbox,
+    Chip,
+    CircularProgress,
+    List,
+    ListItemButton,
+    ListItemIcon,
+    ListItemText,
+    Stack,
+    TablePagination,
+    TextField,
+    Typography,
+} from "@mui/material";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getProblemList } from "@/generated/backend";
+import { queryKeys } from "@/lib/query-keys";
+import { ClearableTextField } from "@/shared/components/ClearableTextField";
+
+const PAGE_SIZE = 20;
+
+interface ProblemSetProblemPickerProps {
+    selectedKeys: string[];
+    onSelectionChange: (keys: string[]) => void;
+}
+
+export function ProblemSetProblemPicker({ selectedKeys, onSelectionChange }: ProblemSetProblemPickerProps) {
+    const { t } = useTranslation("problem-sets");
+    const [page, setPage] = useState(0);
+    const [bookSlug, setBookSlug] = useState("");
+    const [prefix, setPrefix] = useState("");
+
+    const { data = [], isLoading } = useQuery({
+        queryKey: queryKeys.problems.list(
+            page,
+            PAGE_SIZE,
+            prefix || undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            bookSlug || undefined,
+        ),
+        queryFn: ({ signal }) =>
+            getProblemList({ page, size: PAGE_SIZE, bookSlug: bookSlug || undefined, prefix: prefix || undefined }, signal),
+    });
+
+    const toggle = (key: string) => {
+        if (selectedKeys.includes(key)) {
+            onSelectionChange(selectedKeys.filter((k) => k !== key));
+        } else {
+            onSelectionChange([...selectedKeys, key]);
+        }
+    };
+
+    const handleBookSlugChange = (value: string) => {
+        setBookSlug(value);
+        setPage(0);
+    };
+
+    return (
+        <Stack spacing={1}>
+            {selectedKeys.length > 0 && (
+                <Chip
+                    label={t("picker_selected_count", { count: selectedKeys.length })}
+                    size="small"
+                    color="primary"
+                    variant="outlined"
+                    sx={{ alignSelf: "flex-start" }}
+                />
+            )}
+            <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+                <ClearableTextField
+                    label={t("book_label")}
+                    value={bookSlug}
+                    size="small"
+                    onChange={handleBookSlugChange}
+                    onClear={() => {
+                        handleBookSlugChange("");
+                    }}
+                />
+                <TextField
+                    label={t("picker_search_placeholder")}
+                    value={prefix}
+                    size="small"
+                    onChange={(e) => {
+                        setPrefix(e.target.value);
+                        setPage(0);
+                    }}
+                    sx={{ flex: 1 }}
+                />
+            </Stack>
+            {isLoading ? (
+                <CircularProgress size={24} sx={{ mx: "auto" }} />
+            ) : data.length === 0 ? (
+                <Typography color="text.secondary" align="center" py={2}>
+                    {t("picker_no_problems")}
+                </Typography>
+            ) : (
+                <List dense disablePadding sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}>
+                    {data.map((problem) => (
+                        <ListItemButton
+                            key={problem.key}
+                            onClick={() => {
+                                toggle(problem.key);
+                            }}
+                            dense
+                        >
+                            <ListItemIcon sx={{ minWidth: 36 }}>
+                                <Checkbox
+                                    checked={selectedKeys.includes(problem.key)}
+                                    edge="start"
+                                    tabIndex={-1}
+                                    disableRipple
+                                    size="small"
+                                />
+                            </ListItemIcon>
+                            <ListItemText primary={problem.key} secondary={problem.isHard ? "★ Hard" : undefined} />
+                        </ListItemButton>
+                    ))}
+                </List>
+            )}
+            <TablePagination
+                component="div"
+                count={data.length < PAGE_SIZE ? page * PAGE_SIZE + data.length : -1}
+                page={page}
+                onPageChange={(_, newPage) => {
+                    setPage(newPage);
+                }}
+                rowsPerPage={PAGE_SIZE}
+                rowsPerPageOptions={[PAGE_SIZE]}
+            />
+        </Stack>
+    );
+}

--- a/edukate-frontend/src/pages/ProblemSetCreationPage.test.tsx
+++ b/edukate-frontend/src/pages/ProblemSetCreationPage.test.tsx
@@ -4,31 +4,57 @@ import { http, HttpResponse } from "msw";
 import { render, screen, waitFor } from "@/test/render";
 import { server } from "@/test/server";
 import { getCreateProblemSetResponseMock } from "@/generated/backend";
+import { ProblemMetadata } from "@/generated/backend";
 import ProblemSetCreationPage from "./ProblemSetCreationPage";
 
 const LocationSpy = () => <span data-testid="pathname">{useLocation().pathname}</span>;
 
-describe("ProblemSetCreationPage — static rendering", () => {
+const PROBLEM_MOCK: ProblemMetadata = {
+    key: "savchenko/1.1.1",
+    code: "1.1.1",
+    bookSlug: "savchenko",
+    isHard: false,
+    tags: [],
+    status: "NOT_SOLVED",
+    createdAt: "2024-01-01T00:00:00Z",
+    language: "EN",
+};
+
+const problemsHandler = http.get("*/api/v1/problems", () => HttpResponse.json([PROBLEM_MOCK]));
+const emptyProblemsHandler = http.get("*/api/v1/problems", () => HttpResponse.json([]));
+
+describe("ProblemSetCreationPage — static rendering (step 0)", () => {
     it("renders 'Create Problem Set' heading", () => {
         render(<ProblemSetCreationPage />);
         expect(screen.getByRole("heading", { name: /create problem set/i })).toBeInTheDocument();
     });
 
-    it("renders Title, Description, Book, and Problems fields", () => {
+    it("renders Title and Description fields on initial load", () => {
         render(<ProblemSetCreationPage />);
         expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
         expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/book/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/problems/i)).toBeInTheDocument();
     });
 
-    it("renders 'Create Problem Set' button", () => {
+    it("renders the stepper with three steps", () => {
         render(<ProblemSetCreationPage />);
-        expect(screen.getByRole("button", { name: /create problem set/i })).toBeInTheDocument();
+        expect(screen.getByText(/details/i)).toBeInTheDocument();
+        expect(screen.getByText(/problems/i)).toBeInTheDocument();
+        expect(screen.getByText(/invite users/i)).toBeInTheDocument();
+    });
+
+    it("shows Next button but not Create on step 0", () => {
+        render(<ProblemSetCreationPage />);
+        expect(screen.getByRole("button", { name: /next/i })).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /create problem set/i })).not.toBeInTheDocument();
+    });
+
+    it("Next button is disabled when required fields are empty", () => {
+        render(<ProblemSetCreationPage />);
+        expect(screen.getByRole("button", { name: /next/i })).toBeDisabled();
     });
 });
 
-describe("ProblemSetCreationPage — field interactions", () => {
+describe("ProblemSetCreationPage — step 0 interactions", () => {
     it("Title field accepts input", async () => {
         render(<ProblemSetCreationPage />);
         const titleInput = screen.getByLabelText(/title/i);
@@ -42,25 +68,55 @@ describe("ProblemSetCreationPage — field interactions", () => {
         await userEvent.type(descInput, "A great collection of problems");
         expect(descInput).toHaveValue("A great collection of problems");
     });
+
+    it("Next button enables after filling title and description", async () => {
+        render(<ProblemSetCreationPage />);
+        await userEvent.type(screen.getByLabelText(/title/i), "My Set");
+        await userEvent.type(screen.getByLabelText(/description/i), "Desc");
+        expect(screen.getByRole("button", { name: /next/i })).not.toBeDisabled();
+    });
 });
 
-describe("ProblemSetCreationPage — Create Problem Set button", () => {
-    it("clicking the button without filling required fields does not crash", async () => {
+describe("ProblemSetCreationPage — step navigation", () => {
+    it("advances to Problems step and shows Create and Back buttons", async () => {
+        server.use(emptyProblemsHandler);
         render(<ProblemSetCreationPage />);
-        // The mutation throws internally ("Invalid problem set request") — no visible error yet (todo)
-        await userEvent.click(screen.getByRole("button", { name: /create problem set/i }));
+        await userEvent.type(screen.getByLabelText(/title/i), "My Set");
+        await userEvent.type(screen.getByLabelText(/description/i), "Desc");
+        await userEvent.click(screen.getByRole("button", { name: /next/i }));
+
         expect(screen.getByRole("button", { name: /create problem set/i })).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument();
+    });
+
+    it("Create button is disabled on Problems step when no problems selected", async () => {
+        server.use(emptyProblemsHandler);
+        render(<ProblemSetCreationPage />);
+        await userEvent.type(screen.getByLabelText(/title/i), "My Set");
+        await userEvent.type(screen.getByLabelText(/description/i), "Desc");
+        await userEvent.click(screen.getByRole("button", { name: /next/i }));
+
+        expect(screen.getByRole("button", { name: /create problem set/i })).toBeDisabled();
+    });
+
+    it("Back navigates from Problems step to Details", async () => {
+        server.use(emptyProblemsHandler);
+        render(<ProblemSetCreationPage />);
+        await userEvent.type(screen.getByLabelText(/title/i), "My Set");
+        await userEvent.type(screen.getByLabelText(/description/i), "Desc");
+        await userEvent.click(screen.getByRole("button", { name: /next/i }));
+        await userEvent.click(screen.getByRole("button", { name: /back/i }));
+
+        expect(screen.getByLabelText(/title/i)).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: /create problem set/i })).not.toBeInTheDocument();
     });
 });
 
 describe("ProblemSetCreationPage — full creation pipeline", () => {
-    // These tests wait out the 500ms debounce in PrefixOptionInputForm — allow extra time
-    const DEBOUNCE_TIMEOUT = 2000;
-
-    it("fills all fields, selects a problem, creates problem set and navigates to it", async () => {
+    it("fills details, selects a problem, creates problem set and navigates to it", async () => {
         const problemSetResponse = getCreateProblemSetResponseMock({ shareCode: "ps-xyz" });
         server.use(
-            http.get("*/api/v1/problems/by-prefix", () => HttpResponse.json(["savchenko/1.1.1", "savchenko/1.1.2"])),
+            problemsHandler,
             http.post("*/api/v1/problem-sets", () => HttpResponse.json(problemSetResponse)),
         );
 
@@ -71,17 +127,14 @@ describe("ProblemSetCreationPage — full creation pipeline", () => {
             </>,
         );
 
+        // Step 0: fill details
         await userEvent.type(screen.getByLabelText(/title/i), "My Problem Set");
         await userEvent.type(screen.getByLabelText(/description/i), "Test description");
+        await userEvent.click(screen.getByRole("button", { name: /next/i }));
 
-        // Type in the autocomplete — triggers debounced search after 1000ms
-        await userEvent.type(screen.getByRole("combobox"), "1.1");
-
-        // findByRole waits up to DEBOUNCE_TIMEOUT for the option to appear post-debounce
-        const option = await screen.findByRole("option", { name: "savchenko/1.1.1" }, { timeout: DEBOUNCE_TIMEOUT });
-        await userEvent.click(option);
-
-        expect(screen.getByText("savchenko/1.1.1")).toBeInTheDocument();
+        // Step 1: select problem from list
+        await userEvent.click(await screen.findByText("savchenko/1.1.1"));
+        expect(screen.getByRole("button", { name: /create problem set/i })).not.toBeDisabled();
 
         await userEvent.click(screen.getByRole("button", { name: /create problem set/i }));
 
@@ -89,20 +142,7 @@ describe("ProblemSetCreationPage — full creation pipeline", () => {
             () => {
                 expect(screen.getByTestId("pathname")).toHaveTextContent("/problem-sets/ps-xyz");
             },
-            { timeout: DEBOUNCE_TIMEOUT },
+            { timeout: 3000 },
         );
-    }, 10000);
-
-    it("shows the selected problem as a chip in the autocomplete", async () => {
-        server.use(http.get("*/api/v1/problems/by-prefix", () => HttpResponse.json(["savchenko/2.1.1"])));
-
-        render(<ProblemSetCreationPage />);
-
-        await userEvent.type(screen.getByRole("combobox"), "2.1");
-
-        const option = await screen.findByRole("option", { name: "savchenko/2.1.1" }, { timeout: DEBOUNCE_TIMEOUT });
-        await userEvent.click(option);
-
-        expect(screen.getByText("savchenko/2.1.1")).toBeInTheDocument();
     }, 10000);
 });

--- a/edukate-frontend/src/pages/ProblemSetCreationPage.tsx
+++ b/edukate-frontend/src/pages/ProblemSetCreationPage.tsx
@@ -1,110 +1,204 @@
 import {
     Alert,
+    Box,
     Button,
     Card,
     CardActions,
     CardContent,
     CircularProgress,
     Container,
+    FormControlLabel,
     Stack,
+    Step,
+    StepLabel,
+    Stepper,
+    Switch,
     TextField,
     Typography,
 } from "@mui/material";
 import { getApiErrorMessage } from "@/lib/api-error";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { OptionPickerComponent } from "@/shared/components/OptionPicker";
-import { ClearableTextField } from "@/shared/components/ClearableTextField";
 import { CreateProblemSetRequest } from "@/features/problem-sets/types";
 import { useCreateProblemSetMutation } from "@/features/problem-sets/api";
+import { inviteToProblemSet } from "@/generated/backend";
+import { ProblemSetProblemPicker } from "@/features/problem-sets/components/ProblemSetProblemPicker";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
 export default function ProblemSetCreationPage() {
     const { t } = useTranslation("problem-sets");
+    const [activeStep, setActiveStep] = useState(0);
     const [createProblemSetRequest, setCreateProblemSetRequest] = useState<CreateProblemSetRequest>({
         name: "",
         description: "",
         isPublic: false,
         problemKeys: [],
     });
-    const [bookSlugFilter, setBookSlugFilter] = useState("");
-    const extraParams = useMemo(() => (bookSlugFilter ? { bookSlugPrefix: bookSlugFilter } : undefined), [bookSlugFilter]);
+    const [inviteUsernames, setInviteUsernames] = useState<string[]>([]);
+    const [failedInvites, setFailedInvites] = useState<string[]>([]);
+    const [createdShareCode, setCreatedShareCode] = useState<string | null>(null);
 
     const problemSetMutation = useCreateProblemSetMutation(createProblemSetRequest);
-
     const navigate = useNavigate();
+
     useEffect(() => {
         if (problemSetMutation.isSuccess) {
-            void navigate(`/problem-sets/${problemSetMutation.data.shareCode}`);
+            const shareCode = problemSetMutation.data.shareCode;
+            if (inviteUsernames.length === 0) {
+                void navigate(`/problem-sets/${shareCode}`);
+                return;
+            }
+            void Promise.allSettled(
+                inviteUsernames.map((username) => inviteToProblemSet(shareCode, { inviteeName: username })),
+            ).then((results) => {
+                const failed = inviteUsernames.filter((_, i) => results[i].status === "rejected");
+                if (failed.length > 0) {
+                    setFailedInvites(failed);
+                    setCreatedShareCode(shareCode);
+                } else {
+                    void navigate(`/problem-sets/${shareCode}`);
+                }
+            });
         }
-    }, [problemSetMutation.isSuccess, problemSetMutation.data, problemSetMutation.error, navigate]);
+    }, [problemSetMutation.isSuccess, problemSetMutation.data, navigate, inviteUsernames]);
 
-    const createProblemSet = () => {
-        problemSetMutation.mutate();
+    const isStep0Valid = createProblemSetRequest.name.trim() !== "" && createProblemSetRequest.description.trim() !== "";
+    const isCreateEnabled =
+        !problemSetMutation.isPending &&
+        !problemSetMutation.isSuccess &&
+        isStep0Valid &&
+        createProblemSetRequest.problemKeys.length > 0;
+
+    const steps = [t("stepper_step_details"), t("stepper_step_problems"), t("stepper_step_invite_users")];
+
+    const stepContent: Record<number, React.ReactNode> = {
+        0: (
+            <Stack spacing={2}>
+                <TextField
+                    required
+                    label={t("title_label")}
+                    value={createProblemSetRequest.name}
+                    onChange={(e) => {
+                        setCreateProblemSetRequest({ ...createProblemSetRequest, name: e.target.value });
+                    }}
+                />
+                <TextField
+                    required
+                    label={t("description_label")}
+                    value={createProblemSetRequest.description}
+                    onChange={(e) => {
+                        setCreateProblemSetRequest({ ...createProblemSetRequest, description: e.target.value });
+                    }}
+                />
+                <FormControlLabel
+                    control={
+                        <Switch
+                            checked={createProblemSetRequest.isPublic}
+                            onChange={(e) => {
+                                setCreateProblemSetRequest({ ...createProblemSetRequest, isPublic: e.target.checked });
+                            }}
+                        />
+                    }
+                    label={t("visibility_toggle_label")}
+                />
+            </Stack>
+        ),
+        1: (
+            <ProblemSetProblemPicker
+                selectedKeys={createProblemSetRequest.problemKeys}
+                onSelectionChange={(problemKeys) => {
+                    setCreateProblemSetRequest({ ...createProblemSetRequest, problemKeys });
+                }}
+            />
+        ),
+        2: (
+            <OptionPickerComponent
+                optionsUrl="/api/v1/users/by-prefix"
+                selectedOptions={inviteUsernames}
+                label={t("stepper_step_invite_users")}
+                placeholderText={t("search_users_placeholder")}
+                onOptionsChange={setInviteUsernames}
+            />
+        ),
     };
 
     return (
-        <Container maxWidth={"md"}>
+        <Container maxWidth="md">
             <Card>
                 <CardContent>
-                    <Stack spacing={2}>
-                        <Typography component="h1" color={"secondary"} variant={"h5"}>
+                    <Stack spacing={3}>
+                        <Typography component="h1" color="secondary" variant="h5">
                             {t("create_problem_set_title")}
                         </Typography>
-                        <TextField
-                            required
-                            label={t("title_label")}
-                            value={createProblemSetRequest.name}
-                            onChange={(e) => {
-                                setCreateProblemSetRequest({ ...createProblemSetRequest, name: e.target.value });
-                            }}
-                        />
-                        <TextField
-                            required
-                            label={t("description_label")}
-                            value={createProblemSetRequest.description}
-                            onChange={(e) => {
-                                setCreateProblemSetRequest({ ...createProblemSetRequest, description: e.target.value });
-                            }}
-                        />
-                        <ClearableTextField
-                            label={t("book_label")}
-                            value={bookSlugFilter}
-                            size="medium"
-                            onChange={setBookSlugFilter}
-                            onClear={() => {
-                                setBookSlugFilter("");
-                            }}
-                        />
-                        <OptionPickerComponent
-                            optionsUrl={"/api/v1/problems/by-prefix"}
-                            selectedOptions={createProblemSetRequest.problemKeys}
-                            label={t("problems_label")}
-                            placeholderText={t("search_problems_placeholder")}
-                            debounceTime={500}
-                            extraParams={extraParams}
-                            onOptionsChange={(problemKeys) => {
-                                setCreateProblemSetRequest({ ...createProblemSetRequest, problemKeys: problemKeys });
-                            }}
-                        />
+                        <Stepper activeStep={activeStep}>
+                            {steps.map((label) => (
+                                <Step key={label}>
+                                    <StepLabel>{label}</StepLabel>
+                                </Step>
+                            ))}
+                        </Stepper>
+                        <Box>{stepContent[activeStep]}</Box>
                     </Stack>
                 </CardContent>
-
                 <CardActions sx={{ flexDirection: "column", gap: 1 }}>
-                    <Button
-                        variant={"contained"}
-                        sx={{ mx: "auto" }}
-                        disabled={problemSetMutation.isPending}
-                        startIcon={problemSetMutation.isPending ? <CircularProgress size={20} /> : undefined}
-                        onClick={() => {
-                            createProblemSet();
-                        }}
-                    >
-                        {t("create_problem_set_button")}
-                    </Button>
+                    <Stack direction="row" spacing={1} sx={{ mx: "auto" }}>
+                        {activeStep > 0 && (
+                            <Button
+                                variant="outlined"
+                                onClick={() => {
+                                    setActiveStep((s) => s - 1);
+                                }}
+                            >
+                                {t("stepper_back_button")}
+                            </Button>
+                        )}
+                        {activeStep < steps.length - 1 && (
+                            <Button
+                                variant="outlined"
+                                disabled={activeStep === 0 && !isStep0Valid}
+                                onClick={() => {
+                                    setActiveStep((s) => s + 1);
+                                }}
+                            >
+                                {t("stepper_next_button")}
+                            </Button>
+                        )}
+                        {activeStep >= 1 && (
+                            <Button
+                                variant="contained"
+                                disabled={!isCreateEnabled}
+                                startIcon={problemSetMutation.isPending ? <CircularProgress size={20} /> : undefined}
+                                onClick={() => {
+                                    problemSetMutation.mutate();
+                                }}
+                            >
+                                {t("create_problem_set_button")}
+                            </Button>
+                        )}
+                    </Stack>
                     {problemSetMutation.isError && (
                         <Alert severity="error" sx={{ width: "100%" }}>
                             {getApiErrorMessage(problemSetMutation.error)}
+                        </Alert>
+                    )}
+                    {failedInvites.length > 0 && createdShareCode && (
+                        <Alert
+                            severity="warning"
+                            sx={{ width: "100%" }}
+                            action={
+                                <Button
+                                    color="inherit"
+                                    size="small"
+                                    onClick={() => {
+                                        void navigate(`/problem-sets/${createdShareCode}`);
+                                    }}
+                                >
+                                    {t("go_to_problem_set_button")}
+                                </Button>
+                            }
+                        >
+                            {t("invite_failed_message", { users: failedInvites.join(", ") })}
                         </Alert>
                     )}
                 </CardActions>

--- a/edukate-frontend/src/shared/i18n/locales/en/problem-sets.json
+++ b/edukate-frontend/src/shared/i18n/locales/en/problem-sets.json
@@ -69,5 +69,16 @@
     "create_problem_set_button": "Create Problem Set",
     "tab_public": "Public",
     "tab_joined": "Joined",
-    "tab_owned": "Owned"
+    "tab_owned": "Owned",
+    "stepper_step_details": "Details",
+    "stepper_step_problems": "Problems",
+    "stepper_step_invite_users": "Invite Users",
+    "stepper_next_button": "Next",
+    "stepper_back_button": "Back",
+    "picker_search_placeholder": "Search by prefix…",
+    "picker_selected_count": "{{count}} selected",
+    "picker_no_problems": "No problems found",
+    "visibility_toggle_label": "Public",
+    "invite_failed_message": "Could not invite: {{users}}",
+    "go_to_problem_set_button": "Go to problem set"
 }

--- a/edukate-frontend/src/shared/i18n/locales/ru/problem-sets.json
+++ b/edukate-frontend/src/shared/i18n/locales/ru/problem-sets.json
@@ -69,5 +69,16 @@
     "create_problem_set_button": "Создать список задач",
     "tab_public": "Публичные",
     "tab_joined": "Участник",
-    "tab_owned": "Владелец"
+    "tab_owned": "Владелец",
+    "stepper_step_details": "Подробности",
+    "stepper_step_problems": "Задачи",
+    "stepper_step_invite_users": "Пригласить участников",
+    "stepper_next_button": "Далее",
+    "stepper_back_button": "Назад",
+    "picker_search_placeholder": "Поиск по префиксу…",
+    "picker_selected_count": "{{count}} выбрано",
+    "picker_no_problems": "Задачи не найдены",
+    "visibility_toggle_label": "Публичный",
+    "invite_failed_message": "Не удалось пригласить: {{users}}",
+    "go_to_problem_set_button": "Перейти к списку задач"
 }


### PR DESCRIPTION
### What's done:
 * Introduced `ProblemSetProblemPicker` component for problem selection with query-based filtering capabilities.
 * Added `BookIngestionServiceTest` with comprehensive test cases for book and problem ingestion scenarios.
 * Updated `ProblemSetCreationPage` to use a stepper for problem set creation, including details, problems, and user invitations.
 * Enhanced problem set creation flow with multi-step navigation and validation logic.
 * Refactored test cases for `ProblemSetCreationPage` to align with the new multi-step UI implementation.