### PR TITLE
Polish notifications UX and unify frosted-glass design system

### DIFF
--- a/edukate-frontend/src/app/providers.tsx
+++ b/edukate-frontend/src/app/providers.tsx
@@ -17,8 +17,8 @@ export function Providers({ children }: ProvidersProps) {
     return (
         <PwaProvider>
             <QueryClientProvider client={queryClient}>
-                <CssBaseline />
                 <ThemeProvider>
+                    <CssBaseline />
                     <AuthProvider>
                         <CookiesProvider defaultSetOptions={{ path: "/" }}>
                             <DeviceProvider>{children}</DeviceProvider>

--- a/edukate-frontend/src/features/files/components/MobileFileUpload.tsx
+++ b/edukate-frontend/src/features/files/components/MobileFileUpload.tsx
@@ -1,5 +1,7 @@
-import { Box, Button, CircularProgress, Fab, SwipeableDrawer } from "@mui/material";
-import { useState, useRef } from "react";
+import { Box, Button, CircularProgress, Fab } from "@mui/material";
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import { SwipeableDrawer } from "@/shared/components/Styled";
 import { MobileFileInput } from "./MobileFileInput";
 import AddIcon from "@mui/icons-material/Add";
 import { useTranslation } from "react-i18next";
@@ -41,20 +43,21 @@ export function MobileFileUpload({
         }
     };
 
-    const containerRef = useRef<HTMLDivElement>(null);
     return (
-        <Box ref={containerRef} sx={{ position: "relative", height: "100%" }}>
-            <Fab
-                color="primary"
-                aria-label="add"
-                onClick={toggleDrawer(true)}
-                sx={{ position: "fixed", bottom: 16, right: 16, zIndex: 10000, display: isDrawerOpen ? "none" : "flex" }}
-            >
-                <AddIcon />
-            </Fab>
+        <Box>
+            {createPortal(
+                <Fab
+                    color="primary"
+                    aria-label="add"
+                    onClick={toggleDrawer(true)}
+                    sx={{ position: "fixed", bottom: 16, right: 16, display: isDrawerOpen ? "none" : "flex" }}
+                >
+                    <AddIcon />
+                </Fab>,
+                document.body,
+            )}
 
             <SwipeableDrawer
-                container={containerRef.current}
                 anchor="bottom"
                 open={isDrawerOpen}
                 onClose={toggleDrawer(false)}

--- a/edukate-frontend/src/features/files/hooks/useFileStatsDisplayValues.ts
+++ b/edukate-frontend/src/features/files/hooks/useFileStatsDisplayValues.ts
@@ -18,10 +18,7 @@ export const useFileStatsDisplayValues = ({ files, maxFiles, maxSize }: UseFileS
     const currentSize = useMemo(() => files.reduce((total, file) => total + file.size, 0), [files]);
 
     const primaryText = useMemo(
-        () =>
-            files.length > 0
-                ? displayValue(files.length, maxFiles, t("files_selected", { count: files.length }))
-                : t("no_files_selected"),
+        () => (files.length > 0 ? displayValue(files.length, maxFiles, t("files_selected")) : t("no_files_selected")),
         [files.length, maxFiles, t],
     );
 

--- a/edukate-frontend/src/features/notifications/components/NotificationButton.tsx
+++ b/edukate-frontend/src/features/notifications/components/NotificationButton.tsx
@@ -61,11 +61,11 @@ export const NotificationButton: FC = () => {
     };
 
     const onNotificationClick = (notification: BaseNotification) => {
-        const { _type, uuid } = notification;
+        const { _type, uuid, isRead } = notification;
         if (_type === "simple") {
-            markAsReadMutation.mutate([uuid]);
+            if (!isRead) markAsReadMutation.mutate([uuid]);
         } else if (_type === "checked") {
-            markAsReadMutation.mutate([uuid]);
+            if (!isRead) markAsReadMutation.mutate([uuid]);
             handleClose();
             setDrawerSubmissionId(String((notification as CheckedNotification).submissionId));
         } else if (_type === "invite") {

--- a/edukate-frontend/src/features/notifications/components/NotificationDrawer.tsx
+++ b/edukate-frontend/src/features/notifications/components/NotificationDrawer.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react";
-import { Box, SwipeableDrawer } from "@mui/material";
-import { frostedGlass } from "@/shared/components/Styled";
+import { Box } from "@mui/material";
+import { SwipeableDrawer } from "@/shared/components/Styled";
 import { BaseNotification } from "@/features/notifications/types";
 import { NotificationContent } from "./NotificationContent";
 
@@ -20,19 +20,18 @@ export const NotificationDrawer: FC<NotificationDrawerProps> = ({ open, onClose,
         disableSwipeToOpen
         slotProps={{
             paper: {
-                sx: (theme) => ({
+                sx: {
                     borderRadius: "16px 16px 0 0",
                     height: "90vh",
                     display: "flex",
                     flexDirection: "column",
                     overflow: "hidden",
                     pb: "env(safe-area-inset-bottom)",
-                    ...frostedGlass(theme),
-                }),
+                },
             },
         }}
     >
-        <Box sx={{ display: "flex", justifyContent: "center", py: 1 }}>
+        <Box sx={{ display: "flex", justifyContent: "center", py: 1, bgcolor: "background.paper" }}>
             <Box sx={{ width: 32, height: 4, borderRadius: 2, bgcolor: "divider" }} />
         </Box>
         <Box sx={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>

--- a/edukate-frontend/src/features/notifications/components/NotificationItemLayout.tsx
+++ b/edukate-frontend/src/features/notifications/components/NotificationItemLayout.tsx
@@ -1,6 +1,7 @@
-import { FC, ReactNode } from "react";
+import { FC, ReactNode, useLayoutEffect, useRef, useState } from "react";
 import {
     Avatar,
+    Box,
     IconButton,
     ListItem,
     ListItemAvatar,
@@ -12,6 +13,8 @@ import {
 import { DoneAll } from "@mui/icons-material";
 import { useTranslation } from "react-i18next";
 import { formatDate, formatRelative } from "@/shared/utils/date";
+
+const COLLAPSED_MAX_HEIGHT = 60;
 
 interface NotificationItemLayoutProps {
     isRead: boolean;
@@ -36,7 +39,17 @@ export const NotificationItemLayout: FC<NotificationItemLayoutProps> = ({
     onClick,
     onMarkAsRead,
 }) => {
-    const { i18n } = useTranslation();
+    const { i18n, t } = useTranslation("common");
+    const [isExpanded, setIsExpanded] = useState(false);
+    const [isOverflowing, setIsOverflowing] = useState(false);
+    const contentRef = useRef<HTMLDivElement>(null);
+
+    useLayoutEffect(() => {
+        if (contentRef.current) {
+            setIsOverflowing(contentRef.current.scrollHeight > COLLAPSED_MAX_HEIGHT);
+        }
+    }, []);
+
     return (
         <ListItem
             disablePadding
@@ -51,11 +64,7 @@ export const NotificationItemLayout: FC<NotificationItemLayoutProps> = ({
                                 e.stopPropagation();
                                 onMarkAsRead();
                             }}
-                            sx={{
-                                opacity: 0,
-                                transition: "opacity 0.15s",
-                                ".MuiListItem-root:hover &": { opacity: 1 },
-                            }}
+                            sx={{ color: "text.secondary" }}
                         >
                             <DoneAll fontSize="small" />
                         </IconButton>
@@ -68,7 +77,7 @@ export const NotificationItemLayout: FC<NotificationItemLayoutProps> = ({
                 sx={{
                     borderLeft: isRead ? "3px solid transparent" : 3,
                     borderColor: isRead ? "transparent" : "primary.main",
-                    bgcolor: isRead ? "background.default" : "background.paper",
+                    bgcolor: "transparent",
                     py: 1.5,
                     px: 2,
                 }}
@@ -80,20 +89,42 @@ export const NotificationItemLayout: FC<NotificationItemLayoutProps> = ({
                     primary={primary}
                     slotProps={{
                         primary: {
-                            fontWeight: isRead ? "normal" : "bold",
-                            variant: "body2",
+                            fontWeight: isRead ? 500 : 700,
                             component: "div",
                         },
+                        secondary: { component: "div" },
                     }}
                     secondary={
                         <>
-                            {secondary}
+                            <Box
+                                ref={contentRef}
+                                sx={{
+                                    overflow: "hidden",
+                                    maxHeight: isExpanded ? "none" : COLLAPSED_MAX_HEIGHT,
+                                }}
+                            >
+                                {secondary}
+                            </Box>
+                            {isOverflowing && (
+                                <Typography
+                                    component="span"
+                                    variant="caption"
+                                    color="primary"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        setIsExpanded((prev) => !prev);
+                                    }}
+                                    sx={{ cursor: "pointer", display: "block", mt: 0.5 }}
+                                >
+                                    {isExpanded ? t("notification_show_less") : t("notification_show_more")}
+                                </Typography>
+                            )}
                             <Tooltip title={formatDate(createdAt, { locale: i18n.language })} placement="bottom-start">
                                 <Typography
                                     component="span"
                                     variant="caption"
                                     color="text.secondary"
-                                    sx={{ display: "inline-block", mt: 0.5 }}
+                                    sx={{ display: "block", mt: 0.5 }}
                                 >
                                     {formatRelative(createdAt, i18n.language)}
                                 </Typography>

--- a/edukate-frontend/src/features/notifications/components/NotificationListItem.tsx
+++ b/edukate-frontend/src/features/notifications/components/NotificationListItem.tsx
@@ -56,7 +56,9 @@ export const NotificationListItem: FC<NotificationListItemProps> = ({ notificati
                     secondary: (
                         <Typography component="span" variant="body2" color="text.secondary">
                             {n.message}
-                            {` ${t("notification_from")} `}
+                            <br />
+                            {t("notification_from")}
+                            <br />
                             <Typography component="span" variant="body2" color="text.primary" fontWeight="medium">
                                 {n.source}
                             </Typography>

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetCategoryList.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetCategoryList.tsx
@@ -1,4 +1,5 @@
-import { Divider, List, Paper } from "@mui/material";
+import { Divider } from "@mui/material";
+import { List } from "@/shared/components/Styled";
 import { ProblemSetListItem } from "./ProblemSetListItem";
 import { ProblemSetListItemSkeleton } from "./ProblemSetListItemSkeleton";
 import { ProblemSetEmptyState } from "./ProblemSetEmptyState";
@@ -18,16 +19,14 @@ export function ProblemSetCategoryList({ tab, onTabSwitch }: ProblemSetCategoryL
 
     if (isPending) {
         return (
-            <Paper variant="outlined">
-                <List disablePadding>
-                    {Array.from({ length: SKELETON_COUNT }, (_, i) => (
-                        <Fragment key={`skeleton-${String(i)}`}>
-                            {i > 0 && <Divider />}
-                            <ProblemSetListItemSkeleton />
-                        </Fragment>
-                    ))}
-                </List>
-            </Paper>
+            <List disablePadding>
+                {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+                    <Fragment key={`skeleton-${String(i)}`}>
+                        {i > 0 && <Divider />}
+                        <ProblemSetListItemSkeleton />
+                    </Fragment>
+                ))}
+            </List>
         );
     }
 
@@ -36,15 +35,13 @@ export function ProblemSetCategoryList({ tab, onTabSwitch }: ProblemSetCategoryL
     }
 
     return (
-        <Paper variant="outlined">
-            <List disablePadding>
-                {problemSets.map((problemSet, index) => (
-                    <Fragment key={problemSet.shareCode}>
-                        {index > 0 && <Divider />}
-                        <ProblemSetListItem problemSetMetadata={problemSet} />
-                    </Fragment>
-                ))}
-            </List>
-        </Paper>
+        <List disablePadding>
+            {problemSets.map((problemSet, index) => (
+                <Fragment key={problemSet.shareCode}>
+                    {index > 0 && <Divider />}
+                    <ProblemSetListItem problemSetMetadata={problemSet} />
+                </Fragment>
+            ))}
+        </List>
     );
 }

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetComponent.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetComponent.tsx
@@ -1,6 +1,7 @@
 import { useProblemSetRequest } from "@/features/problem-sets/api";
 import { useCallback, useMemo, useState } from "react";
-import { Alert, Box, Card, CircularProgress, Paper, Typography } from "@mui/material";
+import { Alert, Box, CircularProgress, Typography } from "@mui/material";
+import { Card, Paper } from "@/shared/components/Styled";
 import { getApiErrorMessage } from "@/lib/api-error";
 import { ProblemSetProblemSelector, ProblemSetSelection } from "./ProblemSetProblemSelector";
 import { ProblemComponent } from "@/features/problems/components/ProblemComponent";
@@ -63,11 +64,11 @@ export function ProblemSetComponent({ problemSetCode }: ProblemSetComponentProps
                     {selection.type === "problem" ? (
                         <ProblemComponent bookSlug={selection.problem.bookSlug} code={selection.problem.code} />
                     ) : selection.type === "settings" && problemSet ? (
-                        <Paper variant="outlined">
+                        <Paper>
                             <ProblemSetSettingsTab problemSet={problemSet} />
                         </Paper>
                     ) : problemSet ? (
-                        <Paper variant="outlined">
+                        <Paper>
                             <ProblemSetDescriptionTab problemSet={problemSet} />
                         </Paper>
                     ) : null}

--- a/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemPicker.tsx
+++ b/edukate-frontend/src/features/problem-sets/components/ProblemSetProblemPicker.tsx
@@ -98,7 +98,7 @@ export function ProblemSetProblemPicker({ selectedKeys, onSelectionChange }: Pro
                     {t("picker_no_problems")}
                 </Typography>
             ) : (
-                <List dense disablePadding sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}>
+                <List dense disablePadding>
                     {data.map((problem) => (
                         <ListItemButton
                             key={problem.key}

--- a/edukate-frontend/src/features/problems/components/cards/ProblemCard.tsx
+++ b/edukate-frontend/src/features/problems/components/cards/ProblemCard.tsx
@@ -1,4 +1,5 @@
-import { Card, CardContent, Typography } from "@mui/material";
+import { CardContent, Typography } from "@mui/material";
+import { Card } from "@/shared/components/Styled";
 import { Problem } from "@/features/problems/types";
 import { SubproblemsComponent } from "@/features/problems/components/SubproblemsComponent";
 import { LazyLatexComponent } from "@/shared/components/LazyLatexComponent";

--- a/edukate-frontend/src/features/problems/components/cards/SolutionCard.tsx
+++ b/edukate-frontend/src/features/problems/components/cards/SolutionCard.tsx
@@ -1,5 +1,6 @@
 import { Problem } from "@/features/problems/types";
-import { Card, CardContent, Stack, Typography } from "@mui/material";
+import { CardContent, Stack, Typography } from "@mui/material";
+import { Card } from "@/shared/components/Styled";
 import { FileUpload } from "@/features/files/components/FileUpload";
 import { AnswerAccordionComponent } from "@/features/problems/components/AnswerAccordion";
 import { useSubmitProblemMutation } from "@/features/submissions/api";

--- a/edukate-frontend/src/features/problems/components/cards/SubmissionsCard.tsx
+++ b/edukate-frontend/src/features/problems/components/cards/SubmissionsCard.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
-import { Card, CardContent, Paper, Typography } from "@mui/material";
+import { CardContent, Typography } from "@mui/material";
+import { Card, Paper } from "@/shared/components/Styled";
 import { SubmissionList } from "@/features/submissions/components/SubmissionList";
 import { SubmissionDrawer } from "@/features/submissions/components/SubmissionDrawer";
 import { Submission } from "@/features/submissions/types";
@@ -20,11 +21,7 @@ export default function SubmissionsCard({ problemKey }: SubmissionsCardProps) {
                     <Typography color="secondary" variant="h6" paddingBottom={1}>
                         {t("submissions_heading")}
                     </Typography>
-                    <Paper
-                        elevation={0}
-                        variant={"outlined"}
-                        sx={{ width: { xs: "100%", sm: "80%" }, justifyContent: "center", margin: "auto" }}
-                    >
+                    <Paper sx={{ width: { xs: "100%", sm: "80%" }, justifyContent: "center", margin: "auto" }}>
                         <SubmissionList problemKey={problemKey} onSubmissionClick={setSelectedSubmission} />
                     </Paper>
                 </CardContent>

--- a/edukate-frontend/src/features/problems/components/table/ProblemTable.tsx
+++ b/edukate-frontend/src/features/problems/components/table/ProblemTable.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from "react";
-import { Paper, Table, TableBody, TableContainer, TableHead, TableRow, TableCell } from "@mui/material";
+import { Table, TableBody, TableContainer, TableHead, TableRow, TableCell } from "@mui/material";
+import { Paper } from "@/shared/components/Styled";
 
 type ProblemTableProps = {
     headerCells: ReactNode[];

--- a/edukate-frontend/src/features/submissions/components/SubmissionComponent.tsx
+++ b/edukate-frontend/src/features/submissions/components/SubmissionComponent.tsx
@@ -165,9 +165,10 @@ function FilesSection({ fileUrls, onPreview }: { fileUrls: string[]; onPreview: 
                     <Chip
                         key={i}
                         icon={<AttachFileIcon />}
-                        label={`File ${String(i + 1)}`}
+                        label={t("attached_file_label", { index: i + 1 })}
                         size="small"
                         variant="outlined"
+                        color="primary"
                         onClick={() => {
                             onPreview(i);
                         }}

--- a/edukate-frontend/src/features/submissions/components/SubmissionDrawer.tsx
+++ b/edukate-frontend/src/features/submissions/components/SubmissionDrawer.tsx
@@ -1,5 +1,6 @@
 import { FC } from "react";
-import { Box, Divider, Drawer, IconButton, Stack, Typography } from "@mui/material";
+import { Box, Divider, IconButton, Stack, Typography } from "@mui/material";
+import { Drawer } from "@/shared/components/Styled";
 import CloseIcon from "@mui/icons-material/Close";
 import { Submission } from "@/features/submissions/types";
 import { SubmissionComponent } from "@/features/submissions/components/SubmissionComponent";

--- a/edukate-frontend/src/features/submissions/components/SubmissionList.tsx
+++ b/edukate-frontend/src/features/submissions/components/SubmissionList.tsx
@@ -1,6 +1,7 @@
 import { useMySubmissionsQuery } from "@/features/submissions/api";
 import { FC, useState } from "react";
-import { Box, List } from "@mui/material";
+import { Box } from "@mui/material";
+import { List } from "@/shared/components/Styled";
 import { ImageLightbox } from "@/shared/components/images/ImageLightbox";
 import { EmptySubmissionListStub, ErrorListItem, StubListItem, SubmissionListItem } from "./SubmissionListItems";
 import { Submission } from "@/features/submissions/types";

--- a/edukate-frontend/src/features/submissions/components/table/SubmissionTable.tsx
+++ b/edukate-frontend/src/features/submissions/components/table/SubmissionTable.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from "react";
-import { Paper, Table, TableBody, TableContainer, TableHead, TableRow, TableCell } from "@mui/material";
+import { Table, TableBody, TableContainer, TableHead, TableRow, TableCell } from "@mui/material";
+import { Paper } from "@/shared/components/Styled";
 
 type SubmissionTableProps = {
     headerCells: ReactNode[];

--- a/edukate-frontend/src/pages/IndexPage.tsx
+++ b/edukate-frontend/src/pages/IndexPage.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Card, CardContent, Typography } from "@mui/material";
+import { Box, Button, CardContent, Typography } from "@mui/material";
+import { Card } from "@/shared/components/Styled";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 
@@ -15,13 +16,7 @@ export default function IndexPage() {
                 {t("welcome_title")}
             </Typography>
 
-            <Card
-                sx={{
-                    textAlign: "center",
-                    marginTop: "2rem",
-                    padding: "1rem",
-                }}
-            >
+            <Card sx={{ textAlign: "center", marginTop: "2rem", padding: "1rem" }}>
                 <CardContent>
                     <Typography variant="body1" marginBottom={4}>
                         {t("welcome_description")}

--- a/edukate-frontend/src/pages/ProblemSetCreationPage.tsx
+++ b/edukate-frontend/src/pages/ProblemSetCreationPage.tsx
@@ -2,7 +2,6 @@ import {
     Alert,
     Box,
     Button,
-    Card,
     CardActions,
     CardContent,
     Container,
@@ -25,6 +24,7 @@ import { inviteToProblemSet } from "@/generated/backend";
 import { ProblemSetProblemPicker } from "@/features/problem-sets/components/ProblemSetProblemPicker";
 import { useNavigate } from "react-router-dom";
 import { useTranslation } from "react-i18next";
+import { Card } from "@/shared/components/Styled";
 
 export default function ProblemSetCreationPage() {
     const { t } = useTranslation("problem-sets");

--- a/edukate-frontend/src/shared/components/Styled.ts
+++ b/edukate-frontend/src/shared/components/Styled.ts
@@ -1,11 +1,23 @@
-import { Card, Stack, styled, Theme } from "@mui/material";
+import {
+    Card as MuiCard,
+    Drawer as MuiDrawer,
+    List as MuiList,
+    Paper as MuiPaper,
+    Stack,
+    styled,
+    SwipeableDrawer as MuiSwipeableDrawer,
+    Theme,
+} from "@mui/material";
 import Toolbar from "@mui/material/Toolbar";
 import { alpha, CSSObject } from "@mui/material/styles";
 
 export function frostedGlass(theme: Theme, opacity = 0.5): CSSObject {
     return {
-        backdropFilter: "blur(10px)",
-        backgroundColor: alpha(theme.palette.background.default, opacity),
+        backdropFilter: "blur(6px)",
+        backgroundColor: alpha(theme.palette.background.default, 0.65),
+        ...theme.applyStyles("dark", {
+            backgroundColor: alpha(theme.palette.background.default, opacity),
+        }),
     };
 }
 
@@ -22,7 +34,47 @@ export const BlurryToolbar = styled(Toolbar)(({ theme }) => ({
     padding: theme.spacing(1, 1.5),
 }));
 
-export const SignCard = styled(Card)(({ theme }) => ({
+export const Card = styled(MuiCard)(({ theme }) => ({
+    ...frostedGlass(theme),
+    backgroundColor: alpha(theme.palette.background.paper, 0.65),
+    border: "1px solid",
+    borderColor: theme.palette.divider,
+    borderRadius: theme.shape.borderRadius * 3,
+    boxShadow: "none",
+}));
+
+export const Paper = styled(MuiPaper)(({ theme }) => ({
+    ...frostedGlass(theme),
+    backgroundColor: alpha(theme.palette.background.paper, 0.65),
+    border: "1px solid",
+    borderColor: theme.palette.divider,
+    borderRadius: theme.shape.borderRadius * 3,
+    boxShadow: "none",
+}));
+
+export const List = styled(MuiList)(({ theme }) => ({
+    ...frostedGlass(theme),
+    backgroundColor: alpha(theme.palette.background.paper, 0.65),
+    borderRadius: theme.shape.borderRadius * 3,
+    border: "1px solid",
+    borderColor: theme.palette.divider,
+}));
+
+export const Drawer = styled(MuiDrawer)(({ theme }) => ({
+    "& .MuiPaper-root": {
+        ...frostedGlass(theme),
+        backgroundColor: alpha(theme.palette.background.paper, 0.65),
+    },
+}));
+
+export const SwipeableDrawer = styled(MuiSwipeableDrawer)(({ theme }) => ({
+    "& .MuiPaper-root": {
+        ...frostedGlass(theme),
+        backgroundColor: alpha(theme.palette.background.paper, 0.65),
+    },
+}));
+
+export const SignCard = styled(MuiCard)(({ theme }) => ({
     display: "flex",
     flexDirection: "column",
     alignSelf: "center",

--- a/edukate-frontend/src/shared/components/layout/topbar/UserMenu.tsx
+++ b/edukate-frontend/src/shared/components/layout/topbar/UserMenu.tsx
@@ -103,7 +103,7 @@ export function UserMenu() {
                 keepMounted
             >
                 {user && (
-                    <Box sx={{ display: { xs: "block", md: "none" } }}>
+                    <Box>
                         <Box sx={{ px: 2, py: 1.5, display: "flex", alignItems: "center", gap: 1.5 }}>
                             <UserAvatar name={user.name} />
                             <Box>
@@ -129,11 +129,9 @@ export function UserMenu() {
                 aria-expanded={isMenuOpen}
                 color="primary"
                 onClick={handleOpen}
+                sx={{ minWidth: 0, p: 0.5 }}
             >
-                <Typography variant={"body2"} sx={{ display: { xs: "none", md: "flex" }, pr: "0.5rem" }}>
-                    {user ? user.name : "Sign"}
-                </Typography>
-                <AccountCircle />
+                {user ? <UserAvatar name={user.name} /> : <AccountCircle />}
             </Button>
         </Box>
     );

--- a/edukate-frontend/src/shared/components/pwa/InstallPrompt.tsx
+++ b/edukate-frontend/src/shared/components/pwa/InstallPrompt.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Button, IconButton, Snackbar } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import CloseIcon from "@mui/icons-material/Close";
 import { useTranslation } from "react-i18next";
 import { usePwaContext } from "@/shared/context/PwaContext";
+import { frostedGlass } from "@/shared/components/Styled";
 
 export function InstallPrompt() {
     const { canInstall, promptInstall } = usePwaContext();
@@ -14,6 +16,17 @@ export function InstallPrompt() {
             open={canInstall && !dismissed}
             anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
             message={t("install_prompt")}
+            slotProps={{
+                content: {
+                    sx: (theme) => ({
+                        ...frostedGlass(theme),
+                        backgroundColor: alpha(theme.palette.background.paper, 0.65),
+                        border: "1px solid",
+                        borderColor: theme.palette.divider,
+                        color: theme.palette.text.primary,
+                    }),
+                },
+            }}
             action={
                 <>
                     <Button color="secondary" size="small" onClick={promptInstall}>

--- a/edukate-frontend/src/shared/components/pwa/UpdatePrompt.tsx
+++ b/edukate-frontend/src/shared/components/pwa/UpdatePrompt.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
 import { Button, IconButton, Snackbar } from "@mui/material";
+import { alpha } from "@mui/material/styles";
 import CloseIcon from "@mui/icons-material/Close";
 import { usePwaContext } from "@/shared/context/PwaContext";
+import { frostedGlass } from "@/shared/components/Styled";
 
 export function UpdatePrompt() {
     const { updateAvailable, applyUpdate } = usePwaContext();
@@ -12,6 +14,17 @@ export function UpdatePrompt() {
             open={updateAvailable && !dismissed}
             anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
             message="A new version of Edukate is available"
+            slotProps={{
+                content: {
+                    sx: (theme) => ({
+                        ...frostedGlass(theme),
+                        backgroundColor: alpha(theme.palette.background.paper, 0.65),
+                        border: "1px solid",
+                        borderColor: theme.palette.divider,
+                        color: theme.palette.text.primary,
+                    }),
+                },
+            }}
             action={
                 <>
                     <Button color="secondary" size="small" onClick={applyUpdate}>

--- a/edukate-frontend/src/shared/i18n/locales/en/common.json
+++ b/edukate-frontend/src/shared/i18n/locales/en/common.json
@@ -19,7 +19,7 @@
     "max_size_error": "You can upload no more than {{max}}, you have {{current}}.",
     "files_heading": "Files",
     "files_uploaded_count": "Files uploaded",
-    "files_selected": "{{count}} files selected",
+    "files_selected": "files selected",
     "no_files_selected": "No files selected",
     "no_files_yet": "No files yet",
     "image_alt": "Image {{index}}",
@@ -46,7 +46,7 @@
     "notification_problem": "Problem {{problemKey}}",
     "notification_invite_primary": "{{inviterName}} invites you!",
     "notification_join_problem_set": "Join problem set",
-    "notification_from": "from",
+    "notification_from": "Best regards,",
     "notification_default": "Notification",
     "notification_show_more": "Show more",
     "notification_show_less": "Show less"

--- a/edukate-frontend/src/shared/i18n/locales/en/common.json
+++ b/edukate-frontend/src/shared/i18n/locales/en/common.json
@@ -47,5 +47,7 @@
     "notification_invite_primary": "{{inviterName}} invites you!",
     "notification_join_problem_set": "Join problem set",
     "notification_from": "from",
-    "notification_default": "Notification"
+    "notification_default": "Notification",
+    "notification_show_more": "Show more",
+    "notification_show_less": "Show less"
 }

--- a/edukate-frontend/src/shared/i18n/locales/en/submissions.json
+++ b/edukate-frontend/src/shared/i18n/locales/en/submissions.json
@@ -3,6 +3,7 @@
     "problem_label": "Problem",
     "submitted_by_label": "Submitted by",
     "attached_files_label": "Attached files",
+    "attached_file_label": "File {{index}}",
     "no_submissions_yet": "No submissions yet",
     "no_submissions_yet_description": "Your submissions will appear here after you upload a solution.",
     "submissions_load_error": "Failed to load submissions",

--- a/edukate-frontend/src/shared/i18n/locales/ru/common.json
+++ b/edukate-frontend/src/shared/i18n/locales/ru/common.json
@@ -47,5 +47,7 @@
     "notification_invite_primary": "{{inviterName}} приглашает вас!",
     "notification_join_problem_set": "Присоединиться к набору задач",
     "notification_from": "от",
-    "notification_default": "Уведомление"
+    "notification_default": "Уведомление",
+    "notification_show_more": "Развернуть",
+    "notification_show_less": "Свернуть"
 }

--- a/edukate-frontend/src/shared/i18n/locales/ru/common.json
+++ b/edukate-frontend/src/shared/i18n/locales/ru/common.json
@@ -19,7 +19,7 @@
     "max_size_error": "Можно загрузить не более {{max}}, у вас {{current}}.",
     "files_heading": "Файлы",
     "files_uploaded_count": "Файлов загружено",
-    "files_selected": "{{count}} файлов выбрано",
+    "files_selected": "файлов выбрано",
     "no_files_selected": "Файлы не выбраны",
     "no_files_yet": "Файлов пока нет",
     "image_alt": "Изображение {{index}}",
@@ -46,7 +46,7 @@
     "notification_problem": "Задача {{problemKey}}",
     "notification_invite_primary": "{{inviterName}} приглашает вас!",
     "notification_join_problem_set": "Присоединиться к набору задач",
-    "notification_from": "от",
+    "notification_from": "С уважением,",
     "notification_default": "Уведомление",
     "notification_show_more": "Развернуть",
     "notification_show_less": "Свернуть"

--- a/edukate-frontend/src/shared/i18n/locales/ru/submissions.json
+++ b/edukate-frontend/src/shared/i18n/locales/ru/submissions.json
@@ -3,6 +3,7 @@
     "problem_label": "Задача",
     "submitted_by_label": "Отправлено",
     "attached_files_label": "Прикреплённые файлы",
+    "attached_file_label": "Файл {{index}}",
     "no_submissions_yet": "Посылок пока нет",
     "no_submissions_yet_description": "Ваши посылки появятся здесь после загрузки решения.",
     "submissions_load_error": "Не удалось загрузить посылки",

--- a/edukate-notifier/src/main/kotlin/io/github/sanyavertolet/edukate/notifier/configs/DevNotificationSeeder.kt
+++ b/edukate-notifier/src/main/kotlin/io/github/sanyavertolet/edukate/notifier/configs/DevNotificationSeeder.kt
@@ -54,6 +54,7 @@ class DevNotificationSeeder(private val notificationService: NotificationService
         private const val CHECKED_INDEX_OFFSET = 3
         private const val INVITE_INDEX_OFFSET_1 = 7
         private const val INVITE_INDEX_OFFSET_2 = 8
+        private const val LONG_TEXT_INDEX = 9
 
         private fun devUuid(userId: Long, index: Int): String = "dev-seed-$userId-$index"
 
@@ -74,6 +75,18 @@ class DevNotificationSeeder(private val notificationService: NotificationService
                     targetUserId = userId,
                     title = "New problems available",
                     message = "14 chapters of Savchenko problems are now ready to solve.",
+                    source = "edukate",
+                ),
+                SimpleNotificationCreateRequest(
+                    uuid = devUuid(userId, LONG_TEXT_INDEX),
+                    targetUserId = userId,
+                    title = "Platform maintenance completed",
+                    message =
+                        "We have deployed a major update to the Edukate platform. " +
+                            "This includes improved problem rendering with KaTeX support for complex equations, " +
+                            "a fully redesigned submission pipeline, and real-time feedback from our AI-powered checker. " +
+                            "Your saved progress has been preserved. " +
+                            "Please review your open submissions and resubmit if needed.",
                     source = "edukate",
                 ),
             )


### PR DESCRIPTION
## Summary

- **Expandable notifications** — long notification bodies now collapse to 60 px with a "Show more / Show less" toggle, detected via `useLayoutEffect` on mount so there's no layout thrash.
- **Shared styled-component library** (`Styled.ts`) — new `Card`, `Paper`, `List`, `Drawer`, and `SwipeableDrawer` exports carry the frosted-glass treatment (backdrop-blur + semi-transparent fill + `divider` border) in one place. All consumer components migrated from raw MUI imports.
- **Light/dark mode fix** for `frostedGlass()` — opacity is now asymmetric: lighter glass in light mode (`0.65`), original opacity in dark mode via `theme.applyStyles("dark", …)`.
- **MobileFileUpload FAB** rendered via `createPortal` to `document.body`, eliminating stacking-context and `z-index` battles with ancestor drawers.
- **PWA snackbars** (install / update prompts) now share the frosted-glass style.
- **UserMenu** shows a `UserAvatar` chip instead of a plain username string; user info header visible on all screen sizes.
- **Copy improvements** — `notification_from` → `"Best regards,"`, new `notification_show_more` / `notification_show_less` i18n keys (EN + RU), `attached_file_label` added to submissions locale.
